### PR TITLE
修复 Oritech 配方类型识别与 JEI 样板上传

### DIFF
--- a/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
+++ b/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
@@ -19,6 +19,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
@@ -87,7 +88,6 @@ public final class CtrlQPatternKeyHandler {
 
 		List<ItemStack> selectedIngredients = selectIngredientsWithJeiPriority(selected);
 		List<ItemStack> selectedOutputs = convertOutputsToItemStacks(selected);
-		setLastProcessingNameFromRecipe(selected.getRecipeBase());
 
 		PacketDistributor.sendToServer(new CreateCtrlQPatternC2SPacket(
 			selected.getRecipeId(),
@@ -195,18 +195,12 @@ public final class CtrlQPatternKeyHandler {
 			}
 
 			Object recipeBase = null;
-			Object recipeCategory = null;
 			try {
 				var getRecipeMethod = recipeBookmark.getClass().getMethod("getRecipe");
 				recipeBase = getRecipeMethod.invoke(recipeBookmark);
 			} catch (Throwable ignored) {
 			}
-			try {
-				var getCategoryMethod = recipeBookmark.getClass().getMethod("getRecipeCategory");
-				recipeCategory = getCategoryMethod.invoke(recipeBookmark);
-			} catch (Throwable ignored) {
-			}
-			setLastProcessingNameFromRecipe(recipeCategory, recipeBase, recipeOpt.get());
+			setLastProcessingNameFromRecipe(recipeBase != null ? recipeBase : recipeOpt.get());
 
 			List<RecipeInfo> recipeInfos = findRecipeInfosForBookmark(recipeBookmark);
 			if (recipeInfos.isEmpty()) {
@@ -340,13 +334,41 @@ public final class CtrlQPatternKeyHandler {
 		return Optional.empty();
 	}
 
-	private static void setLastProcessingNameFromRecipe(Object... recipeCandidates) {
-		for (Object candidate : recipeCandidates) {
-			String name = ExtendedAEPatternUploadUtil.mapRecipeObjectToSearchKey(candidate);
-			if (name != null && !name.isBlank()) {
-				ExtendedAEPatternUploadUtil.setLastProcessingName(name);
-				return;
+	private static void setLastProcessingNameFromRecipe(Object recipeBase) {
+		String name = null;
+		
+		// 处理 RecipeHolder
+		if (recipeBase != null && "net.minecraft.world.item.crafting.RecipeHolder".equals(recipeBase.getClass().getName())) {
+			try {
+				var valueMethod = recipeBase.getClass().getMethod("value");
+				Object actualRecipe = valueMethod.invoke(recipeBase);
+				if (actualRecipe != null) {
+					recipeBase = actualRecipe;
+				}
+			} catch (Throwable ignored) {
 			}
+		}
+		
+		if (recipeBase instanceof Recipe<?> recipe) {
+			name = ExtendedAEPatternUploadUtil.mapRecipeTypeToSearchKey(recipe);
+		} else if (recipeBase != null
+			&& "com.gregtechceu.gtceu.api.recipe.GTRecipe".equals(recipeBase.getClass().getName())) {
+			name = ExtendedAEPatternUploadUtil.mapGTCEuRecipeToSearchKey(recipeBase);
+		} else if (recipeBase != null
+			&& "com.gregtechceu.gtceu.integration.jei.recipe.GTRecipeWrapper".equals(recipeBase.getClass().getName())) {
+			try {
+				var field = recipeBase.getClass().getField("recipe");
+				Object inner = field.get(recipeBase);
+				name = ExtendedAEPatternUploadUtil.mapGTCEuRecipeToSearchKey(inner);
+			} catch (Throwable ignored) {
+			}
+		}
+
+		if (name == null || name.isBlank()) {
+			name = ExtendedAEPatternUploadUtil.deriveSearchKeyFromUnknownRecipe(recipeBase);
+		}
+		if (name != null && !name.isBlank()) {
+			ExtendedAEPatternUploadUtil.setLastProcessingName(name);
 		}
 	}
 

--- a/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
+++ b/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
@@ -19,7 +19,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
@@ -88,6 +87,7 @@ public final class CtrlQPatternKeyHandler {
 
 		List<ItemStack> selectedIngredients = selectIngredientsWithJeiPriority(selected);
 		List<ItemStack> selectedOutputs = convertOutputsToItemStacks(selected);
+		setLastProcessingNameFromRecipe(selected.getRecipeBase());
 
 		PacketDistributor.sendToServer(new CreateCtrlQPatternC2SPacket(
 			selected.getRecipeId(),
@@ -195,12 +195,18 @@ public final class CtrlQPatternKeyHandler {
 			}
 
 			Object recipeBase = null;
+			Object recipeCategory = null;
 			try {
 				var getRecipeMethod = recipeBookmark.getClass().getMethod("getRecipe");
 				recipeBase = getRecipeMethod.invoke(recipeBookmark);
 			} catch (Throwable ignored) {
 			}
-			setLastProcessingNameFromRecipe(recipeBase != null ? recipeBase : recipeOpt.get());
+			try {
+				var getCategoryMethod = recipeBookmark.getClass().getMethod("getRecipeCategory");
+				recipeCategory = getCategoryMethod.invoke(recipeBookmark);
+			} catch (Throwable ignored) {
+			}
+			setLastProcessingNameFromRecipe(recipeCategory, recipeBase, recipeOpt.get());
 
 			List<RecipeInfo> recipeInfos = findRecipeInfosForBookmark(recipeBookmark);
 			if (recipeInfos.isEmpty()) {
@@ -334,41 +340,13 @@ public final class CtrlQPatternKeyHandler {
 		return Optional.empty();
 	}
 
-	private static void setLastProcessingNameFromRecipe(Object recipeBase) {
-		String name = null;
-		
-		// 处理 RecipeHolder
-		if (recipeBase != null && "net.minecraft.world.item.crafting.RecipeHolder".equals(recipeBase.getClass().getName())) {
-			try {
-				var valueMethod = recipeBase.getClass().getMethod("value");
-				Object actualRecipe = valueMethod.invoke(recipeBase);
-				if (actualRecipe != null) {
-					recipeBase = actualRecipe;
-				}
-			} catch (Throwable ignored) {
+	private static void setLastProcessingNameFromRecipe(Object... recipeCandidates) {
+		for (Object candidate : recipeCandidates) {
+			String name = ExtendedAEPatternUploadUtil.mapRecipeObjectToSearchKey(candidate);
+			if (name != null && !name.isBlank()) {
+				ExtendedAEPatternUploadUtil.setLastProcessingName(name);
+				return;
 			}
-		}
-		
-		if (recipeBase instanceof Recipe<?> recipe) {
-			name = ExtendedAEPatternUploadUtil.mapRecipeTypeToSearchKey(recipe);
-		} else if (recipeBase != null
-			&& "com.gregtechceu.gtceu.api.recipe.GTRecipe".equals(recipeBase.getClass().getName())) {
-			name = ExtendedAEPatternUploadUtil.mapGTCEuRecipeToSearchKey(recipeBase);
-		} else if (recipeBase != null
-			&& "com.gregtechceu.gtceu.integration.jei.recipe.GTRecipeWrapper".equals(recipeBase.getClass().getName())) {
-			try {
-				var field = recipeBase.getClass().getField("recipe");
-				Object inner = field.get(recipeBase);
-				name = ExtendedAEPatternUploadUtil.mapGTCEuRecipeToSearchKey(inner);
-			} catch (Throwable ignored) {
-			}
-		}
-
-		if (name == null || name.isBlank()) {
-			name = ExtendedAEPatternUploadUtil.deriveSearchKeyFromUnknownRecipe(recipeBase);
-		}
-		if (name != null && !name.isBlank()) {
-			ExtendedAEPatternUploadUtil.setLastProcessingName(name);
 		}
 	}
 

--- a/src/main/java/com/extendedae_plus/mixin/jei/AE2JeiEncodePatternTransferHandlerMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/jei/AE2JeiEncodePatternTransferHandlerMixin.java
@@ -1,9 +1,12 @@
 package com.extendedae_plus.mixin.jei;
 
+import appeng.integration.modules.itemlists.EncodingHelper;
+import appeng.menu.me.items.PatternEncodingTermMenu;
 import com.extendedae_plus.util.uploadPattern.ExtendedAEPatternUploadUtil;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,13 +18,10 @@ import tamaized.ae2jeiintegration.integration.modules.jei.transfer.EncodePattern
  * 捕获处理配方并记录一个可用于搜索的关键字，以便 ProviderSelectScreen 自动预填搜索框。
  */
 @Mixin(value = EncodePatternTransferHandler.class, remap = false)
-public abstract class AE2JeiEncodePatternTransferHandlerMixin {
+public abstract class AE2JeiEncodePatternTransferHandlerMixin<T extends PatternEncodingTermMenu> {
 
-    @Inject(
-            method = "transferRecipe(Lnet/minecraft/world/inventory/AbstractContainerMenu;Ljava/lang/Object;Lmezz/jei/api/gui/ingredient/IRecipeSlotsView;Lnet/minecraft/world/entity/player/Player;ZZ)Lmezz/jei/api/recipe/transfer/IRecipeTransferError;",
-            at = @At("HEAD"),
-            remap = false)
-    private void extendedae_plus$captureProcessingName(AbstractContainerMenu menu,
+    @Inject(method = "transferRecipe", at = @At("HEAD"), require = 0, remap = false)
+    private void extendedae_plus$captureProcessingName(T menu,
                                                        Object recipeBase,
                                                        IRecipeSlotsView slotsView,
                                                        Player player,
@@ -29,7 +29,24 @@ public abstract class AE2JeiEncodePatternTransferHandlerMixin {
                                                        boolean doTransfer,
                                                        CallbackInfoReturnable<mezz.jei.api.recipe.transfer.IRecipeTransferError> cir) {
         if (!doTransfer) return;
-        String name = ExtendedAEPatternUploadUtil.mapRecipeObjectToSearchKey(recipeBase);
+        String name = null;
+        Recipe<?> recipe = null;
+        if (recipeBase instanceof RecipeHolder<?> holder) {
+            recipe = holder.value();
+        } else if (recipeBase instanceof Recipe<?> r) {
+            // 部分模组（如 Oritech）向 JEI 注册的是未包装的 Recipe 对象而非 RecipeHolder
+            recipe = r;
+        }
+        if (recipe != null) {
+            if (EncodingHelper.isSupportedCraftingRecipe(recipe)) {
+                ExtendedAEPatternUploadUtil.presetCraftingProviderSearchKey();
+                return;
+            }
+            name = ExtendedAEPatternUploadUtil.mapRecipeTypeToSearchKey(recipe);
+        } else {
+            // 非原版 Recipe<?> 的显示，尝试从 recipeBase 类名/包名推导关键词
+            name = ExtendedAEPatternUploadUtil.deriveSearchKeyFromUnknownRecipe(recipeBase);
+        }
         if (name != null && !name.isBlank()) {
             ExtendedAEPatternUploadUtil.setLastProcessingName(name);
         }

--- a/src/main/java/com/extendedae_plus/mixin/jei/AE2JeiEncodePatternTransferHandlerMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/jei/AE2JeiEncodePatternTransferHandlerMixin.java
@@ -33,6 +33,9 @@ public abstract class AE2JeiEncodePatternTransferHandlerMixin<T extends PatternE
         Recipe<?> recipe = null;
         if (recipeBase instanceof RecipeHolder<?> holder) {
             recipe = holder.value();
+        } else if (recipeBase instanceof Recipe<?> r) {
+            // 部分模组（如 Oritech）向 JEI 注册的是未包装的 Recipe 对象而非 RecipeHolder
+            recipe = r;
         }
         if (recipe != null) {
             if (EncodingHelper.isSupportedCraftingRecipe(recipe)) {

--- a/src/main/java/com/extendedae_plus/mixin/jei/AE2JeiEncodePatternTransferHandlerMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/jei/AE2JeiEncodePatternTransferHandlerMixin.java
@@ -1,12 +1,9 @@
 package com.extendedae_plus.mixin.jei;
 
-import appeng.integration.modules.itemlists.EncodingHelper;
-import appeng.menu.me.items.PatternEncodingTermMenu;
 import com.extendedae_plus.util.uploadPattern.ExtendedAEPatternUploadUtil;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,10 +15,13 @@ import tamaized.ae2jeiintegration.integration.modules.jei.transfer.EncodePattern
  * 捕获处理配方并记录一个可用于搜索的关键字，以便 ProviderSelectScreen 自动预填搜索框。
  */
 @Mixin(value = EncodePatternTransferHandler.class, remap = false)
-public abstract class AE2JeiEncodePatternTransferHandlerMixin<T extends PatternEncodingTermMenu> {
+public abstract class AE2JeiEncodePatternTransferHandlerMixin {
 
-    @Inject(method = "transferRecipe", at = @At("HEAD"), require = 0, remap = false)
-    private void extendedae_plus$captureProcessingName(T menu,
+    @Inject(
+            method = "transferRecipe(Lnet/minecraft/world/inventory/AbstractContainerMenu;Ljava/lang/Object;Lmezz/jei/api/gui/ingredient/IRecipeSlotsView;Lnet/minecraft/world/entity/player/Player;ZZ)Lmezz/jei/api/recipe/transfer/IRecipeTransferError;",
+            at = @At("HEAD"),
+            remap = false)
+    private void extendedae_plus$captureProcessingName(AbstractContainerMenu menu,
                                                        Object recipeBase,
                                                        IRecipeSlotsView slotsView,
                                                        Player player,
@@ -29,24 +29,7 @@ public abstract class AE2JeiEncodePatternTransferHandlerMixin<T extends PatternE
                                                        boolean doTransfer,
                                                        CallbackInfoReturnable<mezz.jei.api.recipe.transfer.IRecipeTransferError> cir) {
         if (!doTransfer) return;
-        String name = null;
-        Recipe<?> recipe = null;
-        if (recipeBase instanceof RecipeHolder<?> holder) {
-            recipe = holder.value();
-        } else if (recipeBase instanceof Recipe<?> r) {
-            // 部分模组（如 Oritech）向 JEI 注册的是未包装的 Recipe 对象而非 RecipeHolder
-            recipe = r;
-        }
-        if (recipe != null) {
-            if (EncodingHelper.isSupportedCraftingRecipe(recipe)) {
-                ExtendedAEPatternUploadUtil.presetCraftingProviderSearchKey();
-                return;
-            }
-            name = ExtendedAEPatternUploadUtil.mapRecipeTypeToSearchKey(recipe);
-        } else {
-            // 非原版 Recipe<?> 的显示，尝试从 recipeBase 类名/包名推导关键词
-            name = ExtendedAEPatternUploadUtil.deriveSearchKeyFromUnknownRecipe(recipeBase);
-        }
+        String name = ExtendedAEPatternUploadUtil.mapRecipeObjectToSearchKey(recipeBase);
         if (name != null && !name.isBlank()) {
             ExtendedAEPatternUploadUtil.setLastProcessingName(name);
         }

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
@@ -475,6 +475,19 @@ public class ExtendedAEPatternUploadUtil {
      */
     public static String deriveSearchKeyFromUnknownRecipe(Object recipeBase) {
         if (recipeBase == null) return null;
+        // 优先尝试反射 getType()：覆盖“单一配方类 + 类型字段”设计的模组（如 Oritech），
+        // 避免所有机器配方被类名推导成同一个关键字。
+        try {
+            Object type = recipeBase.getClass().getMethod("getType").invoke(recipeBase);
+            if (type instanceof RecipeType<?> rt) {
+                ResourceLocation key = BuiltInRegistries.RECIPE_TYPE.getKey(rt);
+                if (key != null) {
+                    String resolved = resolveSearchKeyAlias(key.getPath());
+                    if (resolved != null && !resolved.isBlank()) return resolved;
+                }
+            }
+        } catch (Throwable ignored) {
+        }
         try {
             Class<?> cls = recipeBase.getClass();
             String simple = cls.getSimpleName();

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
@@ -38,6 +38,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -426,17 +427,129 @@ public class ExtendedAEPatternUploadUtil {
 
     public static String mapRecipeTypeToSearchKey(Recipe<?> recipe) {
         if (recipe == null) return null;
-        RecipeType<?> type = recipe.getType();
-        ResourceLocation key = BuiltInRegistries.RECIPE_TYPE.getKey(type);
+        ResourceLocation key = getRecipeTypeId(recipe.getType());
         if (key == null) return null;
-        String resolvedPath = resolveSearchKeyAlias(key.getPath());
-        if (resolvedPath != null) return resolvedPath;
-        // 再查完整ID映射
+        return mapRecipeTypeIdToSearchKey(key);
+    }
+
+    /**
+     * Maps recipe objects received from JEI, including holders and mod-specific wrappers.
+     */
+    public static String mapRecipeObjectToSearchKey(Object recipeBase) {
+        return mapRecipeObjectToSearchKey(recipeBase,
+                Collections.newSetFromMap(new IdentityHashMap<>()), 0);
+    }
+
+    private static String mapRecipeObjectToSearchKey(Object recipeBase, Set<Object> visited, int depth) {
+        if (recipeBase == null || depth > 4 || !visited.add(recipeBase)) {
+            return null;
+        }
+        if (recipeBase instanceof RecipeHolder<?> holder) {
+            return mapRecipeObjectToSearchKey(holder.value(), visited, depth + 1);
+        }
+        if (recipeBase instanceof Recipe<?> recipe) {
+            if (appeng.integration.modules.itemlists.EncodingHelper.isSupportedCraftingRecipe(recipe)) {
+                return resolveSearchKeyAlias(DEFAULT_CRAFTING_SEARCH_KEY);
+            }
+            String mapped = mapRecipeTypeToSearchKey(recipe);
+            if (mapped != null && !mapped.isBlank()) {
+                return mapped;
+            }
+        }
+        if ("com.gregtechceu.gtceu.api.recipe.GTRecipe".equals(recipeBase.getClass().getName())) {
+            String mapped = mapGTCEuRecipeToSearchKey(recipeBase);
+            if (mapped != null && !mapped.isBlank()) {
+                return mapped;
+            }
+        }
+
+        ResourceLocation typeId = getRecipeTypeIdFromObject(recipeBase);
+        if (typeId != null) {
+            return mapRecipeTypeIdToSearchKey(typeId);
+        }
+
+        for (String methodName : List.of("getRecipe", "recipe", "value")) {
+            try {
+                Object inner = recipeBase.getClass().getMethod(methodName).invoke(recipeBase);
+                String mapped = mapRecipeObjectToSearchKey(inner, visited, depth + 1);
+                if (mapped != null && !mapped.isBlank()) {
+                    return mapped;
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        for (String fieldName : List.of("recipe", "value", "delegate")) {
+            try {
+                Field field = recipeBase.getClass().getDeclaredField(fieldName);
+                field.setAccessible(true);
+                String mapped = mapRecipeObjectToSearchKey(field.get(recipeBase), visited, depth + 1);
+                if (mapped != null && !mapped.isBlank()) {
+                    return mapped;
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return deriveSearchKeyFromUnknownRecipe(recipeBase);
+    }
+
+    private static String mapRecipeTypeIdToSearchKey(ResourceLocation key) {
         String custom = CUSTOM_NAMES.get(key);
         if (custom != null && !custom.isBlank()) {
             return custom;
         }
-        return key.getPath();
+        return resolveSearchKeyAlias(key.getPath());
+    }
+
+    private static ResourceLocation getRecipeTypeIdFromObject(Object recipeBase) {
+        for (String methodName : List.of("getType", "getOriType", "getRecipeType")) {
+            try {
+                Object type = recipeBase.getClass().getMethod(methodName).invoke(recipeBase);
+                ResourceLocation id = getRecipeTypeId(type);
+                if (id != null) {
+                    return id;
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static ResourceLocation getRecipeTypeId(Object type) {
+        if (type == null) {
+            return null;
+        }
+        if (type instanceof ResourceLocation id) {
+            return id;
+        }
+        ResourceLocation exposed = getExposedTypeId(type);
+        if (exposed != null) {
+            return exposed;
+        }
+        if (type instanceof RecipeType<?> recipeType) {
+            ResourceLocation registered = BuiltInRegistries.RECIPE_TYPE.getKey(recipeType);
+            if (registered != null) {
+                return registered;
+            }
+        }
+        return null;
+    }
+
+    private static ResourceLocation getExposedTypeId(Object type) {
+        // Oritech and JEI expose stable identifiers directly on their type objects.
+        for (String methodName : List.of("getIdentifier", "getUid", "location")) {
+            try {
+                Object id = type.getClass().getMethod(methodName).invoke(type);
+                if (id instanceof ResourceLocation resourceLocation) {
+                    return resourceLocation;
+                }
+                ResourceLocation parsed = id != null ? ResourceLocation.tryParse(id.toString()) : null;
+                if (parsed != null) {
+                    return parsed;
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return null;
     }
 
     // 注意：GTCEu 的映射方法已在下方提供基于 Object 的反射版本，避免重复定义。
@@ -475,18 +588,9 @@ public class ExtendedAEPatternUploadUtil {
      */
     public static String deriveSearchKeyFromUnknownRecipe(Object recipeBase) {
         if (recipeBase == null) return null;
-        // 优先尝试反射 getType()：覆盖“单一配方类 + 类型字段”设计的模组（如 Oritech），
-        // 避免所有机器配方被类名推导成同一个关键字。
-        try {
-            Object type = recipeBase.getClass().getMethod("getType").invoke(recipeBase);
-            if (type instanceof RecipeType<?> rt) {
-                ResourceLocation key = BuiltInRegistries.RECIPE_TYPE.getKey(rt);
-                if (key != null) {
-                    String resolved = resolveSearchKeyAlias(key.getPath());
-                    if (resolved != null && !resolved.isBlank()) return resolved;
-                }
-            }
-        } catch (Throwable ignored) {
+        ResourceLocation typeId = getRecipeTypeIdFromObject(recipeBase);
+        if (typeId != null) {
+            return mapRecipeTypeIdToSearchKey(typeId);
         }
         try {
             Class<?> cls = recipeBase.getClass();

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
@@ -38,7 +38,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -427,129 +426,17 @@ public class ExtendedAEPatternUploadUtil {
 
     public static String mapRecipeTypeToSearchKey(Recipe<?> recipe) {
         if (recipe == null) return null;
-        ResourceLocation key = getRecipeTypeId(recipe.getType());
+        RecipeType<?> type = recipe.getType();
+        ResourceLocation key = BuiltInRegistries.RECIPE_TYPE.getKey(type);
         if (key == null) return null;
-        return mapRecipeTypeIdToSearchKey(key);
-    }
-
-    /**
-     * Maps recipe objects received from JEI, including holders and mod-specific wrappers.
-     */
-    public static String mapRecipeObjectToSearchKey(Object recipeBase) {
-        return mapRecipeObjectToSearchKey(recipeBase,
-                Collections.newSetFromMap(new IdentityHashMap<>()), 0);
-    }
-
-    private static String mapRecipeObjectToSearchKey(Object recipeBase, Set<Object> visited, int depth) {
-        if (recipeBase == null || depth > 4 || !visited.add(recipeBase)) {
-            return null;
-        }
-        if (recipeBase instanceof RecipeHolder<?> holder) {
-            return mapRecipeObjectToSearchKey(holder.value(), visited, depth + 1);
-        }
-        if (recipeBase instanceof Recipe<?> recipe) {
-            if (appeng.integration.modules.itemlists.EncodingHelper.isSupportedCraftingRecipe(recipe)) {
-                return resolveSearchKeyAlias(DEFAULT_CRAFTING_SEARCH_KEY);
-            }
-            String mapped = mapRecipeTypeToSearchKey(recipe);
-            if (mapped != null && !mapped.isBlank()) {
-                return mapped;
-            }
-        }
-        if ("com.gregtechceu.gtceu.api.recipe.GTRecipe".equals(recipeBase.getClass().getName())) {
-            String mapped = mapGTCEuRecipeToSearchKey(recipeBase);
-            if (mapped != null && !mapped.isBlank()) {
-                return mapped;
-            }
-        }
-
-        ResourceLocation typeId = getRecipeTypeIdFromObject(recipeBase);
-        if (typeId != null) {
-            return mapRecipeTypeIdToSearchKey(typeId);
-        }
-
-        for (String methodName : List.of("getRecipe", "recipe", "value")) {
-            try {
-                Object inner = recipeBase.getClass().getMethod(methodName).invoke(recipeBase);
-                String mapped = mapRecipeObjectToSearchKey(inner, visited, depth + 1);
-                if (mapped != null && !mapped.isBlank()) {
-                    return mapped;
-                }
-            } catch (Throwable ignored) {
-            }
-        }
-        for (String fieldName : List.of("recipe", "value", "delegate")) {
-            try {
-                Field field = recipeBase.getClass().getDeclaredField(fieldName);
-                field.setAccessible(true);
-                String mapped = mapRecipeObjectToSearchKey(field.get(recipeBase), visited, depth + 1);
-                if (mapped != null && !mapped.isBlank()) {
-                    return mapped;
-                }
-            } catch (Throwable ignored) {
-            }
-        }
-        return deriveSearchKeyFromUnknownRecipe(recipeBase);
-    }
-
-    private static String mapRecipeTypeIdToSearchKey(ResourceLocation key) {
+        String resolvedPath = resolveSearchKeyAlias(key.getPath());
+        if (resolvedPath != null) return resolvedPath;
+        // 再查完整ID映射
         String custom = CUSTOM_NAMES.get(key);
         if (custom != null && !custom.isBlank()) {
             return custom;
         }
-        return resolveSearchKeyAlias(key.getPath());
-    }
-
-    private static ResourceLocation getRecipeTypeIdFromObject(Object recipeBase) {
-        for (String methodName : List.of("getType", "getOriType", "getRecipeType")) {
-            try {
-                Object type = recipeBase.getClass().getMethod(methodName).invoke(recipeBase);
-                ResourceLocation id = getRecipeTypeId(type);
-                if (id != null) {
-                    return id;
-                }
-            } catch (Throwable ignored) {
-            }
-        }
-        return null;
-    }
-
-    private static ResourceLocation getRecipeTypeId(Object type) {
-        if (type == null) {
-            return null;
-        }
-        if (type instanceof ResourceLocation id) {
-            return id;
-        }
-        ResourceLocation exposed = getExposedTypeId(type);
-        if (exposed != null) {
-            return exposed;
-        }
-        if (type instanceof RecipeType<?> recipeType) {
-            ResourceLocation registered = BuiltInRegistries.RECIPE_TYPE.getKey(recipeType);
-            if (registered != null) {
-                return registered;
-            }
-        }
-        return null;
-    }
-
-    private static ResourceLocation getExposedTypeId(Object type) {
-        // Oritech and JEI expose stable identifiers directly on their type objects.
-        for (String methodName : List.of("getIdentifier", "getUid", "location")) {
-            try {
-                Object id = type.getClass().getMethod(methodName).invoke(type);
-                if (id instanceof ResourceLocation resourceLocation) {
-                    return resourceLocation;
-                }
-                ResourceLocation parsed = id != null ? ResourceLocation.tryParse(id.toString()) : null;
-                if (parsed != null) {
-                    return parsed;
-                }
-            } catch (Throwable ignored) {
-            }
-        }
-        return null;
+        return key.getPath();
     }
 
     // 注意：GTCEu 的映射方法已在下方提供基于 Object 的反射版本，避免重复定义。
@@ -588,9 +475,18 @@ public class ExtendedAEPatternUploadUtil {
      */
     public static String deriveSearchKeyFromUnknownRecipe(Object recipeBase) {
         if (recipeBase == null) return null;
-        ResourceLocation typeId = getRecipeTypeIdFromObject(recipeBase);
-        if (typeId != null) {
-            return mapRecipeTypeIdToSearchKey(typeId);
+        // 优先尝试反射 getType()：覆盖“单一配方类 + 类型字段”设计的模组（如 Oritech），
+        // 避免所有机器配方被类名推导成同一个关键字。
+        try {
+            Object type = recipeBase.getClass().getMethod("getType").invoke(recipeBase);
+            if (type instanceof RecipeType<?> rt) {
+                ResourceLocation key = BuiltInRegistries.RECIPE_TYPE.getKey(rt);
+                if (key != null) {
+                    String resolved = resolveSearchKeyAlias(key.getPath());
+                    if (resolved != null && !resolved.isBlank()) return resolved;
+                }
+            }
+        } catch (Throwable ignored) {
         }
         try {
             Class<?> cls = recipeBase.getClass();


### PR DESCRIPTION
## 变更内容

- 兼容 JEI 传入未经过 `RecipeHolder` 包装的 `Recipe<?>` 对象，确保 Oritech 配方能进入正常的编码与上传流程。
- 对未知配方优先调用 `getType()` 并通过 `RecipeType` 注册名推导搜索键，再回退到原有的类名推导逻辑。
- 使原子锻造器、铸造器、装配器等 Oritech 机器配方能够按实际配方类型分别识别，避免全部归类为 `oritech`。

## 原因

Oritech 向 JEI 注册的部分配方是直接的 `Recipe` 对象，并且多个机器配方共用相同的 Java 配方类。原逻辑仅处理 `RecipeHolder`，未知配方又只按类名推导，因此不同机器配方会被归到同一个搜索键。

## 验证

- Minecraft 1.21.1 / NeoForge
- 已执行完整 Gradle 构建，构建成功
- 生成产物：`extendedae_plus-1.5.5.jar`

Closes #90