### PR TITLE
fix: traverse superclass in findField for Mixin-added fields

### DIFF
--- a/src/main/java/com/extendedae_plus/compat/UpgradeSlotCompat.java
+++ b/src/main/java/com/extendedae_plus/compat/UpgradeSlotCompat.java
@@ -171,13 +171,17 @@ public final class UpgradeSlotCompat {
     }
 
     private static Field findField(Class<?> owner, String[] candidates) {
-        for (String candidate : candidates) {
-            try {
-                Field field = owner.getDeclaredField(candidate);
-                field.setAccessible(true);
-                return field;
-            } catch (NoSuchFieldException ignored) {
+        Class<?> clazz = owner;
+        while (clazz != null && clazz != Object.class) {
+            for (String candidate : candidates) {
+                try {
+                    Field field = clazz.getDeclaredField(candidate);
+                    field.setAccessible(true);
+                    return field;
+                } catch (NoSuchFieldException ignored) {
+                }
             }
+            clazz = clazz.getSuperclass();
         }
         return null;
     }


### PR DESCRIPTION
MeteoritePatternProviderLogic and other PatternProviderLogic subclasses have af_$upgrades field declared in the parent class by Appflux mixin. Class.getDeclaredField() only searches the exact class, not superclasses. Added parent class traversal to locate fields in the inheritance chain.

Fixes upgrade slots stuck at 1 (Appflux default) when subclass pattern providers are instantiated before the base class.