### PR TITLE
fix: traverse superclass in findField for Mixin-added fields

### DIFF
--- a/src/main/java/com/extendedae_plus/compat/UpgradeSlotCompat.java
+++ b/src/main/java/com/extendedae_plus/compat/UpgradeSlotCompat.java
@@ -171,13 +171,17 @@ public final class UpgradeSlotCompat {
     }
 
     private static Field findField(Class<?> owner, String[] candidates) {
-        for (String candidate : candidates) {
-            try {
-                Field field = owner.getDeclaredField(candidate);
-                field.setAccessible(true);
-                return field;
-            } catch (NoSuchFieldException ignored) {
+        Class<?> clazz = owner;
+        while (clazz != null && clazz != Object.class) {
+            for (String candidate : candidates) {
+                try {
+                    Field field = clazz.getDeclaredField(candidate);
+                    field.setAccessible(true);
+                    return field;
+                } catch (NoSuchFieldException ignored) {
+                }
             }
+            clazz = clazz.getSuperclass();
         }
         return null;
     }


### PR DESCRIPTION
问题：MeteoritePatternProviderLogic（ae2cs 等模组的 PatternProviderLogic 子类）的升级槽位只有 1 个（Appflux 默认值），无法扩展至 2/5 个。频道卡放入后不生效。

根因：UpgradeSlotCompat.findField() 使用 Class.getDeclaredField() 仅查找本类声明的字段，但 af_$upgrades 由 Appflux Mixin 在父类 PatternProviderLogic 中注入。子类首次调用时查找失败 → 返回 null → 结果被静态缓存永久锁定。

修复：findField() 加入 getSuperclass() 循环遍历继承链。

测试：在包含 Appflux + ae2cs + ExtendedAE 的环境中验证，样板供应器升级槽位恢复正常。