### PR TITLE
fix: 修复缺失合成的合成状态与持久化问题 / Fix missing-item ordering's status display and persistence issues

### DIFF
--- a/src/main/java/com/extendedae_plus/mixin/advancedae/crafting/AdvCraftingCPULogicManualWaitingMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/advancedae/crafting/AdvCraftingCPULogicManualWaitingMixin.java
@@ -8,18 +8,26 @@ import appeng.api.networking.crafting.ICraftingSubmitResult;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.KeyCounter;
+import appeng.crafting.inv.ListCraftingInventory;
 import com.extendedae_plus.api.crafting.IForcedCraftingPlan;
 import com.extendedae_plus.api.crafting.IManualCraftingState;
 import com.extendedae_plus.crafting.ForcedCraftingPlan;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPU;
 import net.pedroksl.advanced_ae.common.logic.AdvCraftingCPULogic;
+import net.pedroksl.advanced_ae.common.logic.ExecutingCraftingJob;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -27,15 +35,34 @@ import java.util.Set;
 @Mixin(value = AdvCraftingCPULogic.class, remap = false)
 public abstract class AdvCraftingCPULogicManualWaitingMixin implements IManualCraftingState {
     @Unique
+    private static final String EAP_MANUAL_WAITING_NBT_KEY = "extendedae_plus:manual_waiting";
+
+    @Shadow
+    private AdvCraftingCPU cpu;
+
+    @Shadow
+    private ExecutingCraftingJob job;
+
+    @Shadow
+    private ListCraftingInventory inventory;
+
+    @Shadow
+    protected abstract void postChange(AEKey what);
+
+    @Unique
     private final Map<AEKey, Long> eap$manualWaitingFor = new LinkedHashMap<>();
 
     @Override
     public void eap$setManualWaiting(KeyCounter manualWaiting) {
-        this.eap$clearManualWaitingInternal();
+        this.eap$clearManualWaitingInternal(false);
         for (var entry : manualWaiting) {
             if (entry.getKey() != null && entry.getLongValue() > 0) {
                 this.eap$manualWaitingFor.put(entry.getKey(), entry.getLongValue());
+                this.postChange(entry.getKey());
             }
+        }
+        if (!this.eap$manualWaitingFor.isEmpty()) {
+            this.cpu.markDirty();
         }
     }
 
@@ -69,14 +96,14 @@ public abstract class AdvCraftingCPULogicManualWaitingMixin implements IManualCr
         if (manualMissing != null) {
             this.eap$setManualWaiting(manualMissing);
         } else {
-            this.eap$clearManualWaitingInternal();
+            this.eap$clearManualWaitingInternal(false);
         }
     }
 
     @Inject(method = "insert", at = @At("RETURN"), cancellable = true)
     private void eap$consumeManualWaitingAfterVanilla(AEKey what, long amount, Actionable type,
             CallbackInfoReturnable<Long> cir) {
-        if (what == null) {
+        if (what == null || this.job == null) {
             return;
         }
 
@@ -94,6 +121,9 @@ public abstract class AdvCraftingCPULogicManualWaitingMixin implements IManualCr
         long consumed = Math.min(remainingAmount, manualWaiting);
         if (type == Actionable.MODULATE) {
             this.eap$decreaseManualWaiting(what, consumed);
+            this.cpu.markDirty();
+            this.postChange(what);
+            this.inventory.insert(what, consumed, Actionable.MODULATE);
         }
 
         cir.setReturnValue(vanillaInserted + consumed);
@@ -124,7 +154,41 @@ public abstract class AdvCraftingCPULogicManualWaitingMixin implements IManualCr
 
     @Inject(method = "finishJob", at = @At("HEAD"))
     private void eap$clearManualWaitingOnFinish(boolean success, CallbackInfo ci) {
-        this.eap$clearManualWaitingInternal();
+        this.eap$clearManualWaitingInternal(true);
+    }
+
+    @Inject(method = "writeToNBT(Lnet/minecraft/nbt/CompoundTag;)V", at = @At("TAIL"))
+    private void eap$writeManualWaitingToNbt(CompoundTag data, CallbackInfo ci) {
+        data.remove(EAP_MANUAL_WAITING_NBT_KEY);
+        if (this.job == null || this.eap$manualWaitingFor.isEmpty()) {
+            return;
+        }
+
+        var entries = new ListTag();
+        for (var entry : this.eap$manualWaitingFor.entrySet()) {
+            var entryTag = entry.getKey().toTagGeneric();
+            entryTag.putLong("#", entry.getValue());
+            entries.add(entryTag);
+        }
+        data.put(EAP_MANUAL_WAITING_NBT_KEY, entries);
+    }
+
+    @Inject(method = "readFromNBT(Lnet/minecraft/nbt/CompoundTag;)V", at = @At("TAIL"))
+    private void eap$readManualWaitingFromNbt(CompoundTag data, CallbackInfo ci) {
+        this.eap$manualWaitingFor.clear();
+        if (this.job == null) {
+            return;
+        }
+
+        var entries = data.getList(EAP_MANUAL_WAITING_NBT_KEY, Tag.TAG_COMPOUND);
+        for (int i = 0; i < entries.size(); i++) {
+            var entryTag = entries.getCompound(i);
+            var key = AEKey.fromTagGeneric(entryTag);
+            long amount = entryTag.getLong("#");
+            if (key != null && amount > 0) {
+                this.eap$manualWaitingFor.put(key, amount);
+            }
+        }
     }
 
     @Unique
@@ -138,10 +202,18 @@ public abstract class AdvCraftingCPULogicManualWaitingMixin implements IManualCr
     }
 
     @Unique
-    private void eap$clearManualWaitingInternal() {
+    private void eap$clearManualWaitingInternal(boolean notifyChanges) {
         if (this.eap$manualWaitingFor.isEmpty()) {
             return;
         }
+
+        var previousKeys = new ArrayList<>(this.eap$manualWaitingFor.keySet());
         this.eap$manualWaitingFor.clear();
+        if (notifyChanges) {
+            for (var key : previousKeys) {
+                this.postChange(key);
+            }
+        }
+        this.cpu.markDirty();
     }
 }

--- a/src/main/java/com/extendedae_plus/mixin/advancedae/menu/CraftingCPUMenuManualStatusAdvancedMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/advancedae/menu/CraftingCPUMenuManualStatusAdvancedMixin.java
@@ -8,6 +8,7 @@ import com.extendedae_plus.init.ModNetwork;
 import com.extendedae_plus.network.crafting.ManualCraftingStatusS2CPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.pedroksl.advanced_ae.common.cluster.AdvCraftingCPU;
+import net.pedroksl.advanced_ae.gui.quantumcomputer.QuantumComputerMenu;
 import net.minecraftforge.network.PacketDistributor;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -19,7 +20,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Mixin(value = CraftingCPUMenu.class, remap = false)
+@Mixin(value = QuantumComputerMenu.class, priority = 1100, remap = false)
 public abstract class CraftingCPUMenuManualStatusAdvancedMixin {
     @Unique
     private AdvCraftingCPU eap$advancedaeSelectedCpu;
@@ -27,11 +28,14 @@ public abstract class CraftingCPUMenuManualStatusAdvancedMixin {
     @Unique
     private Map<AEKey, Long> eap$advancedaeLastManualWaitingSnapshot = Collections.emptyMap();
 
-    @Inject(method = "setCPU", at = @At("HEAD"))
+    @Inject(
+            method = "setCPU(Lappeng/api/networking/crafting/ICraftingCPU;)V",
+            at = @At("HEAD"))
     private void eap$trackAdvancedAeCpu(ICraftingCPU cpu, CallbackInfo ci) {
-        this.eap$advancedaeSelectedCpu = cpu instanceof AdvCraftingCPU advCpu ? advCpu : null;
-        if (this.eap$advancedaeSelectedCpu == null) {
-            this.eap$advancedaeLastManualWaitingSnapshot = Collections.emptyMap();
+        AdvCraftingCPU selectedCpu = cpu instanceof AdvCraftingCPU advCpu ? advCpu : null;
+        if (this.eap$advancedaeSelectedCpu != selectedCpu) {
+            this.eap$advancedaeSelectedCpu = selectedCpu;
+            this.eap$advancedaeLastManualWaitingSnapshot = null;
         }
     }
 
@@ -41,12 +45,10 @@ public abstract class CraftingCPUMenuManualStatusAdvancedMixin {
         if (self.isClientSide() || !(self.getPlayer() instanceof ServerPlayer serverPlayer)) {
             return;
         }
-        if (this.eap$advancedaeSelectedCpu == null) {
-            return;
-        }
 
         Map<AEKey, Long> snapshot = Collections.emptyMap();
-        if (this.eap$advancedaeSelectedCpu.craftingLogic instanceof IManualCraftingState manualState) {
+        if (this.eap$advancedaeSelectedCpu != null
+                && this.eap$advancedaeSelectedCpu.craftingLogic instanceof IManualCraftingState manualState) {
             snapshot = manualState.eap$getManualWaitingSnapshot();
         }
 

--- a/src/main/java/com/extendedae_plus/mixin/advancedae/menu/CraftingCPUMenuManualStatusAdvancedMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/advancedae/menu/CraftingCPUMenuManualStatusAdvancedMixin.java
@@ -35,7 +35,7 @@ public abstract class CraftingCPUMenuManualStatusAdvancedMixin {
         }
     }
 
-    @Inject(method = "broadcastChanges", at = @At("TAIL"))
+    @Inject(method = "broadcastChanges()V", at = @At("TAIL"), remap = true)
     private void eap$syncAdvancedAeManualWaitingStatus(CallbackInfo ci) {
         CraftingCPUMenu self = (CraftingCPUMenu) (Object) this;
         if (self.isClientSide() || !(self.getPlayer() instanceof ServerPlayer serverPlayer)) {

--- a/src/main/java/com/extendedae_plus/mixin/ae2/client/gui/CraftingStatusTableRendererMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/ae2/client/gui/CraftingStatusTableRendererMixin.java
@@ -1,10 +1,12 @@
 package com.extendedae_plus.mixin.ae2.client.gui;
 
+import appeng.api.client.AEKeyRendering;
 import appeng.api.stacks.AmountFormat;
 import appeng.api.util.AEColor;
 import appeng.client.gui.me.crafting.CraftingCPUScreen;
 import appeng.client.gui.me.crafting.CraftingStatusTableRenderer;
 import appeng.core.AEConfig;
+import appeng.core.localization.GuiText;
 import appeng.menu.me.crafting.CraftingStatusEntry;
 import com.extendedae_plus.content.ClientManualCraftingStatusStore;
 import net.minecraft.ChatFormatting;
@@ -35,19 +37,47 @@ public abstract class CraftingStatusTableRendererMixin {
         }
     }
 
-    @Inject(method = "getEntryTooltip", at = @At("RETURN"), cancellable = true)
-    private void eap$appendManualWaitingTooltip(CraftingStatusEntry entry,
+    @Inject(
+            method = "getEntryDescription(Lappeng/menu/me/crafting/CraftingStatusEntry;)Ljava/util/List;",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void eap$replaceManualWaitingDescription(CraftingStatusEntry entry,
             CallbackInfoReturnable<List<Component>> cir) {
         long manualWaiting = this.eap$getManualWaitingAmount(entry);
         if (manualWaiting <= 0 || entry.getWhat() == null) {
             return;
         }
 
-        List<Component> lines = new ArrayList<>(cir.getReturnValue());
-        lines.add(Component.translatable(
-                "tooltip.extendedae_plus.crafting.manual_waiting",
-                entry.getWhat().formatAmount(manualWaiting, AmountFormat.FULL)).withStyle(ChatFormatting.AQUA));
+        List<Component> lines = new ArrayList<>(2);
+        lines.add(GuiText.FromStorage.text(
+                entry.getWhat().formatAmount(entry.getStoredAmount(), AmountFormat.SLOT)));
+        lines.add(this.eap$manualWaitingLine(entry, manualWaiting, AmountFormat.SLOT));
         cir.setReturnValue(lines);
+    }
+
+    @Inject(
+            method = "getEntryTooltip(Lappeng/menu/me/crafting/CraftingStatusEntry;)Ljava/util/List;",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void eap$replaceManualWaitingTooltip(CraftingStatusEntry entry,
+            CallbackInfoReturnable<List<Component>> cir) {
+        long manualWaiting = this.eap$getManualWaitingAmount(entry);
+        if (manualWaiting <= 0 || entry.getWhat() == null) {
+            return;
+        }
+
+        List<Component> lines = AEKeyRendering.getTooltip(entry.getWhat());
+        lines.add(GuiText.FromStorage.text(
+                entry.getWhat().formatAmount(entry.getStoredAmount(), AmountFormat.FULL)));
+        lines.add(this.eap$manualWaitingLine(entry, manualWaiting, AmountFormat.FULL));
+        cir.setReturnValue(lines);
+    }
+
+    @Unique
+    private Component eap$manualWaitingLine(CraftingStatusEntry entry, long manualWaiting, AmountFormat format) {
+        return Component.translatable(
+                "tooltip.extendedae_plus.crafting.manual_waiting",
+                entry.getWhat().formatAmount(manualWaiting, format)).withStyle(ChatFormatting.AQUA);
     }
 
     @Unique

--- a/src/main/java/com/extendedae_plus/mixin/ae2/crafting/CraftingCpuLogicManualWaitingMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/ae2/crafting/CraftingCpuLogicManualWaitingMixin.java
@@ -14,6 +14,9 @@ import appeng.crafting.inv.ListCraftingInventory;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import com.extendedae_plus.api.crafting.IForcedCraftingPlan;
 import com.extendedae_plus.api.crafting.IManualCraftingState;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -30,6 +33,9 @@ import java.util.Set;
 
 @Mixin(value = CraftingCpuLogic.class, remap = false)
 public abstract class CraftingCpuLogicManualWaitingMixin implements IManualCraftingState {
+    @Unique
+    private static final String EAP_MANUAL_WAITING_NBT_KEY = "extendedae_plus:manual_waiting";
+
     @Shadow
     private CraftingCPUCluster cluster;
 
@@ -141,6 +147,40 @@ public abstract class CraftingCpuLogicManualWaitingMixin implements IManualCraft
     @Inject(method = "finishJob", at = @At("HEAD"))
     private void eap$clearManualWaitingOnFinish(boolean success, CallbackInfo ci) {
         this.eap$clearManualWaitingInternal(true);
+    }
+
+    @Inject(method = "writeToNBT(Lnet/minecraft/nbt/CompoundTag;)V", at = @At("TAIL"))
+    private void eap$writeManualWaitingToNbt(CompoundTag data, CallbackInfo ci) {
+        data.remove(EAP_MANUAL_WAITING_NBT_KEY);
+        if (this.job == null || this.eap$manualWaitingFor.isEmpty()) {
+            return;
+        }
+
+        var entries = new ListTag();
+        for (var entry : this.eap$manualWaitingFor.entrySet()) {
+            var entryTag = entry.getKey().toTagGeneric();
+            entryTag.putLong("#", entry.getValue());
+            entries.add(entryTag);
+        }
+        data.put(EAP_MANUAL_WAITING_NBT_KEY, entries);
+    }
+
+    @Inject(method = "readFromNBT(Lnet/minecraft/nbt/CompoundTag;)V", at = @At("TAIL"))
+    private void eap$readManualWaitingFromNbt(CompoundTag data, CallbackInfo ci) {
+        this.eap$manualWaitingFor.clear();
+        if (this.job == null) {
+            return;
+        }
+
+        var entries = data.getList(EAP_MANUAL_WAITING_NBT_KEY, Tag.TAG_COMPOUND);
+        for (int i = 0; i < entries.size(); i++) {
+            var entryTag = entries.getCompound(i);
+            var key = AEKey.fromTagGeneric(entryTag);
+            long amount = entryTag.getLong("#");
+            if (key != null && amount > 0) {
+                this.eap$manualWaitingFor.put(key, amount);
+            }
+        }
     }
 
     @Unique

--- a/src/main/java/com/extendedae_plus/mixin/ae2/menu/CraftingCPUMenuManualStatusMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/ae2/menu/CraftingCPUMenuManualStatusMixin.java
@@ -1,5 +1,6 @@
 package com.extendedae_plus.mixin.ae2.menu;
 
+import appeng.api.networking.crafting.ICraftingCPU;
 import appeng.api.stacks.AEKey;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.menu.me.crafting.CraftingCPUMenu;
@@ -9,7 +10,6 @@ import com.extendedae_plus.network.crafting.ManualCraftingStatusS2CPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.PacketDistributor;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -19,13 +19,23 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Mixin(value = CraftingCPUMenu.class, remap = false)
+@Mixin(value = CraftingCPUMenu.class, priority = 1100, remap = false)
 public abstract class CraftingCPUMenuManualStatusMixin {
-    @Shadow
-    private CraftingCPUCluster cpu;
+    @Unique
+    private ICraftingCPU eap$selectedCpu;
 
     @Unique
     private Map<AEKey, Long> eap$lastManualWaitingSnapshot = Collections.emptyMap();
+
+    @Inject(
+            method = "setCPU(Lappeng/api/networking/crafting/ICraftingCPU;)V",
+            at = @At("HEAD"))
+    private void eap$trackSelectedCpu(ICraftingCPU cpu, CallbackInfo ci) {
+        if (this.eap$selectedCpu != cpu) {
+            this.eap$selectedCpu = cpu;
+            this.eap$lastManualWaitingSnapshot = null;
+        }
+    }
 
     @Inject(method = "broadcastChanges()V", at = @At("TAIL"), remap = true)
     private void eap$syncManualWaitingStatus(CallbackInfo ci) {
@@ -35,8 +45,12 @@ public abstract class CraftingCPUMenuManualStatusMixin {
         }
 
         Map<AEKey, Long> snapshot = Collections.emptyMap();
-        if (this.cpu != null && this.cpu.craftingLogic instanceof IManualCraftingState manualState) {
-            snapshot = manualState.eap$getManualWaitingSnapshot();
+        if (this.eap$selectedCpu instanceof CraftingCPUCluster selectedCpu) {
+            if (selectedCpu.craftingLogic instanceof IManualCraftingState manualState) {
+                snapshot = manualState.eap$getManualWaitingSnapshot();
+            }
+        } else if (this.eap$selectedCpu != null) {
+            return;
         }
 
         if (snapshot.equals(this.eap$lastManualWaitingSnapshot)) {

--- a/src/main/java/com/extendedae_plus/mixin/ae2/menu/CraftingCPUMenuManualStatusMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/ae2/menu/CraftingCPUMenuManualStatusMixin.java
@@ -27,7 +27,7 @@ public abstract class CraftingCPUMenuManualStatusMixin {
     @Unique
     private Map<AEKey, Long> eap$lastManualWaitingSnapshot = Collections.emptyMap();
 
-    @Inject(method = "broadcastChanges", at = @At("TAIL"))
+    @Inject(method = "broadcastChanges()V", at = @At("TAIL"), remap = true)
     private void eap$syncManualWaitingStatus(CallbackInfo ci) {
         CraftingCPUMenu self = (CraftingCPUMenu) (Object) this;
         if (self.isClientSide() || !(self.getPlayer() instanceof ServerPlayer serverPlayer)) {


### PR DESCRIPTION
## 变更内容 / Changes

- 修正了 AE2 15.4.10 中合成 CPU 状态同步 Mixin 的注入目标，使缺失合成状态能够正常同步到客户端。  
  Fixed the crafting CPU status synchronization Mixin target for AE2 15.4.10, allowing missing-item ordering states to be correctly synchronized to the client.

- 修改了缺失合成状态的显示，当且仅当物品处于缺失合成状态时，将列表和 Tooltip 中的 `Crafting` 替换为 `Manual waiting`，并显示紫色背景。  
  Updated the missing-item ordering display. Only while an item is in the missing-item state, `Crafting` is replaced with `Manual waiting` in both the status list and tooltip, and the entry is displayed with a purple background.

- 持久化普通 AE2 CPU 的缺失合成材料表，确保退出并重新进入存档后，缺失合成任务仍能等待补料并继续执行。  
  Persisted the missing-item table for standard AE2 CPUs, ensuring that affected crafting jobs continue waiting for replenishment and can resume after leaving and reopening the world.

- 同步修复了 AdvancedAE CPU 的缺失合成兼容，使其行为与普通 AE2 CPU 保持一致。  
  Applied the corresponding missing-item ordering fixes to AdvancedAE CPUs, keeping their behavior consistent with standard AE2 CPUs.

## 原因 / Cause

原状态同步 Mixin 的 `broadcastChanges` 注入无法匹配 AE2 15.4.10 的运行时方法，导致客户端无法收到手动等待状态，因此缺失材料仍显示为普通合成条目。

The original `broadcastChanges` injection used by the status synchronization Mixin could not match the AE2 15.4.10 runtime method. As a result, the client did not receive the manual-waiting state, and missing materials were displayed as normal crafting entries.

同时，手动等待状态原先仅保存在内存中，存档重新加载后会丢失。

Additionally, the manual-waiting state was previously stored only in memory and was lost when the world was reloaded.

## 验证 / Verification

- Minecraft 1.20.1 / Forge
- Applied Energistics 2 15.4.10
- 已执行完整 Gradle 构建，构建成功。  
  Completed a full Gradle build successfully.
- 已检查发布 JAR 中的 Mixin 配置及运行时映射。  
  Verified the Mixin configuration and runtime mappings in the release JAR.
- 生成产物 / Generated artifact：`extendedae_plus-1.5.5.jar`

Closes #95