### PR TITLE
feat: 在 JEI 界面显示 AE2 网络存量与可合成标识

### DIFF
--- a/src/main/java/com/extendedae_plus/ExtendedAEPlus.java
+++ b/src/main/java/com/extendedae_plus/ExtendedAEPlus.java
@@ -14,6 +14,7 @@ import com.extendedae_plus.content.matrix.supermatrix.SuperAssemblerMatrixFrameB
 import com.extendedae_plus.content.matrix.supermatrix.SuperAssemblerMatrixWallBlockEntity;
 import com.extendedae_plus.init.*;
 import com.extendedae_plus.menu.locator.CuriosItemLocator;
+import com.extendedae_plus.server.JeiSyncManager;
 import com.extendedae_plus.util.command.InfinityDiskGiveCommand;
 import com.extendedae_plus.util.storage.InfinityStorageManager;
 import net.minecraft.resources.ResourceLocation;
@@ -70,6 +71,8 @@ public class ExtendedAEPlus {
         MinecraftForge.EVENT_BUS.addListener(ExtendedAEPlus::onServerStarted);
         MinecraftForge.EVENT_BUS.addListener(ExtendedAEPlus::onServerStopping);
         MinecraftForge.EVENT_BUS.addListener(ExtendedAEPlus::onServerStopped);
+        // 注册 JEI 网络存量同步
+        MinecraftForge.EVENT_BUS.register(JeiSyncManager.class);
         // 注册通用配置
         ModConfig.init();
         MinecraftForge.EVENT_BUS.addListener(ExtendedAEPlus::worldTick);

--- a/src/main/java/com/extendedae_plus/client/jei/JeiOverlayRenderer.java
+++ b/src/main/java/com/extendedae_plus/client/jei/JeiOverlayRenderer.java
@@ -1,0 +1,83 @@
+package com.extendedae_plus.client.jei;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+
+public class JeiOverlayRenderer {
+
+    private static final char[] POSTFIXES = {'K', 'M', 'G', 'T', 'P', 'E'};
+
+    public static void renderOverlay(GuiGraphics guiGraphics, int x, int y, long amount, boolean craftable) {
+        if (amount <= 0 && !craftable) return;
+
+        Font font = Minecraft.getInstance().font;
+        PoseStack poseStack = guiGraphics.pose();
+
+        if (amount > 0) {
+            String text = formatAmount(amount, 3);
+            renderSizeLabel(guiGraphics, font, x, y, text);
+            if (craftable) {
+                renderCraftableMarker(guiGraphics, font, x, y);
+            }
+        } else if (craftable) {
+            renderSizeLabel(guiGraphics, font, x, y, "Craft");
+        }
+    }
+
+    private static void renderSizeLabel(GuiGraphics guiGraphics, Font font, int slotX, int slotY, String text) {
+        PoseStack poseStack = guiGraphics.pose();
+        poseStack.pushPose();
+        poseStack.translate(0, 0, 200);
+
+        float scaleFactor = 0.5f;
+        int width = font.width(text);
+
+        float renderX = (slotX + 16 - width * scaleFactor) / scaleFactor;
+        float renderY = (slotY + 16 - 7 * scaleFactor) / scaleFactor;
+
+        poseStack.scale(scaleFactor, scaleFactor, scaleFactor);
+        guiGraphics.drawString(font, text, (int) renderX, (int) renderY, 0xFFFFFF, true);
+        poseStack.popPose();
+    }
+
+    private static void renderCraftableMarker(GuiGraphics guiGraphics, Font font, int slotX, int slotY) {
+        PoseStack poseStack = guiGraphics.pose();
+        poseStack.pushPose();
+        poseStack.translate(0, 0, 200);
+
+        float scaleFactor = 0.5f;
+        float renderX = (slotX + 1) / scaleFactor;
+        float renderY = (slotY + 1) / scaleFactor;
+
+        poseStack.scale(scaleFactor, scaleFactor, scaleFactor);
+        guiGraphics.drawString(font, "+", (int) renderX, (int) renderY, 0xFFFFFF, true);
+        poseStack.popPose();
+    }
+
+    public static String formatAmount(long number, int width) {
+        if (number < 0) return String.valueOf(number);
+
+        String plain = Long.toString(number);
+        if (plain.length() <= width) return plain;
+
+        long base = number;
+        double last = base * 1000.0;
+        int exponent = -1;
+
+        while (Long.toString(base).length() + 1 > width) {
+            last = base;
+            base /= 1000;
+            exponent++;
+            if (exponent >= POSTFIXES.length - 1) break;
+        }
+
+        String postFix = String.valueOf(POSTFIXES[exponent]);
+        String withPrecision = String.format("%.1f", last / 1000.0) + postFix;
+        String withoutPrecision = base + postFix;
+
+        if (withPrecision.length() <= width) return withPrecision;
+        return withoutPrecision;
+    }
+}

--- a/src/main/java/com/extendedae_plus/client/jei/NetworkItemCache.java
+++ b/src/main/java/com/extendedae_plus/client/jei/NetworkItemCache.java
@@ -1,0 +1,86 @@
+package com.extendedae_plus.client.jei;
+
+import appeng.api.stacks.AEKey;
+import com.extendedae_plus.network.jei.SyncNetworkInventoryS2CPacket;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NetworkItemCache {
+
+    public static final NetworkItemCache INSTANCE = new NetworkItemCache();
+
+    private final Long2ObjectOpenHashMap<CacheEntry> bySerial = new Long2ObjectOpenHashMap<>();
+    private final Map<AEKey, Long> keyToSerial = new HashMap<>();
+    private volatile boolean connected = false;
+
+    public void handleUpdate(boolean fullUpdate, List<SyncNetworkInventoryS2CPacket.Entry> entries) {
+        if (fullUpdate) {
+            clear();
+        }
+        for (var entry : entries) {
+            if (entry.amount == 0 && !entry.craftable) {
+                // removal
+                CacheEntry existing = bySerial.remove(entry.serial);
+                if (existing != null) {
+                    keyToSerial.remove(existing.what);
+                }
+            } else if (entry.what != null) {
+                // new key or full update entry
+                CacheEntry prev = bySerial.get(entry.serial);
+                if (prev != null && prev.what != null) {
+                    keyToSerial.remove(prev.what);
+                }
+                CacheEntry ce = new CacheEntry(entry.what, entry.amount, entry.craftable);
+                bySerial.put(entry.serial, ce);
+                keyToSerial.put(entry.what, entry.serial);
+            } else {
+                // incremental update (key already known by serial)
+                CacheEntry existing = bySerial.get(entry.serial);
+                if (existing != null) {
+                    existing.amount = entry.amount;
+                    existing.craftable = entry.craftable;
+                }
+            }
+        }
+        connected = true;
+    }
+
+    public long getAmount(AEKey key) {
+        Long serial = keyToSerial.get(key);
+        if (serial == null) return 0;
+        CacheEntry entry = bySerial.get(serial.longValue());
+        return entry != null ? entry.amount : 0;
+    }
+
+    public boolean isCraftable(AEKey key) {
+        Long serial = keyToSerial.get(key);
+        if (serial == null) return false;
+        CacheEntry entry = bySerial.get(serial.longValue());
+        return entry != null && entry.craftable;
+    }
+
+    public boolean isConnected() {
+        return connected;
+    }
+
+    public void clear() {
+        bySerial.clear();
+        keyToSerial.clear();
+        connected = false;
+    }
+
+    public static class CacheEntry {
+        public final AEKey what;
+        public long amount;
+        public boolean craftable;
+
+        public CacheEntry(AEKey what, long amount, boolean craftable) {
+            this.what = what;
+            this.amount = amount;
+            this.craftable = craftable;
+        }
+    }
+}

--- a/src/main/java/com/extendedae_plus/init/ModNetwork.java
+++ b/src/main/java/com/extendedae_plus/init/ModNetwork.java
@@ -8,6 +8,7 @@ import com.extendedae_plus.network.crafting.CraftingMonitorOpenProviderC2SPacket
 import com.extendedae_plus.network.crafting.ManualCraftingStatusS2CPacket;
 import com.extendedae_plus.network.crafting.OpenCraftFromJeiC2SPacket;
 import com.extendedae_plus.network.crafting.SetSearchTextS2CPacket;
+import com.extendedae_plus.network.jei.SyncNetworkInventoryS2CPacket;
 import com.extendedae_plus.network.meInterface.InterfaceAdjustConfigAmountC2SPacket;
 import com.extendedae_plus.network.pattern.CancelPendingPatternC2SPacket;
 import com.extendedae_plus.network.pattern.CreateCtrlQPatternC2SPacket;
@@ -245,6 +246,12 @@ public final class ModNetwork {
                 .encoder(TagInventoryFilterC2SPacket::encode)
                 .decoder(TagInventoryFilterC2SPacket::decode)
                 .consumerNetworkThread(TagInventoryFilterC2SPacket::handle)
+                .add();
+
+        CHANNEL.messageBuilder(SyncNetworkInventoryS2CPacket.class, nextId(), NetworkDirection.PLAY_TO_CLIENT)
+                .encoder(SyncNetworkInventoryS2CPacket::encode)
+                .decoder(SyncNetworkInventoryS2CPacket::decode)
+                .consumerNetworkThread(SyncNetworkInventoryS2CPacket::handle)
                 .add();
     }
 

--- a/src/main/java/com/extendedae_plus/mixin/jei/IngredientListRendererMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/jei/IngredientListRendererMixin.java
@@ -1,0 +1,63 @@
+package com.extendedae_plus.mixin.jei;
+
+import appeng.api.stacks.AEItemKey;
+import com.extendedae_plus.client.jei.JeiOverlayRenderer;
+import com.extendedae_plus.client.jei.NetworkItemCache;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.gui.overlay.IngredientListRenderer;
+import mezz.jei.gui.overlay.IngredientListSlot;
+import mezz.jei.gui.overlay.elements.IElement;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(value = IngredientListRenderer.class, remap = false)
+public class IngredientListRendererMixin {
+
+    @Shadow
+    @Final
+    private List<IngredientListSlot> slots;
+
+    @Inject(method = "render", at = @At("TAIL"))
+    private void eap$renderNetworkOverlay(GuiGraphics guiGraphics, CallbackInfo ci) {
+        if (!NetworkItemCache.INSTANCE.isConnected()) return;
+
+        for (IngredientListSlot slot : this.slots) {
+            if (slot.isBlocked()) continue;
+
+            var optElement = slot.getOptionalElement();
+            if (optElement.isEmpty()) continue;
+
+            IElement<?> element = optElement.get();
+            ITypedIngredient<?> typed = element.getTypedIngredient();
+
+            if (typed.getType() != VanillaTypes.ITEM_STACK) continue;
+
+            ItemStack itemStack = (ItemStack) typed.getIngredient();
+            if (itemStack.isEmpty()) continue;
+
+            AEItemKey key = AEItemKey.of(itemStack);
+            if (key == null) continue;
+
+            long amount = NetworkItemCache.INSTANCE.getAmount(key);
+            boolean craftable = NetworkItemCache.INSTANCE.isCraftable(key);
+
+            if (amount <= 0 && !craftable) continue;
+
+            var area = slot.getArea();
+            int padding = slot.getPadding();
+            int renderX = area.getX() + padding;
+            int renderY = area.getY() + padding;
+
+            JeiOverlayRenderer.renderOverlay(guiGraphics, renderX, renderY, amount, craftable);
+        }
+    }
+}

--- a/src/main/java/com/extendedae_plus/network/jei/SyncNetworkInventoryS2CPacket.java
+++ b/src/main/java/com/extendedae_plus/network/jei/SyncNetworkInventoryS2CPacket.java
@@ -1,0 +1,81 @@
+package com.extendedae_plus.network.jei;
+
+import appeng.api.stacks.AEKey;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class SyncNetworkInventoryS2CPacket {
+
+    private final boolean fullUpdate;
+    private final List<Entry> entries;
+
+    public SyncNetworkInventoryS2CPacket(boolean fullUpdate, List<Entry> entries) {
+        this.fullUpdate = fullUpdate;
+        this.entries = entries;
+    }
+
+    public static void encode(SyncNetworkInventoryS2CPacket msg, FriendlyByteBuf buf) {
+        buf.writeBoolean(msg.fullUpdate);
+        buf.writeVarInt(msg.entries.size());
+        for (var entry : msg.entries) {
+            buf.writeVarLong(entry.serial);
+            boolean hasKey = entry.what != null;
+            buf.writeBoolean(hasKey);
+            if (hasKey) {
+                AEKey.writeOptionalKey(buf, entry.what);
+            }
+            buf.writeVarLong(entry.amount);
+            buf.writeBoolean(entry.craftable);
+        }
+    }
+
+    public static SyncNetworkInventoryS2CPacket decode(FriendlyByteBuf buf) {
+        boolean fullUpdate = buf.readBoolean();
+        int size = buf.readVarInt();
+        List<Entry> entries = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            long serial = buf.readVarLong();
+            AEKey what = null;
+            if (buf.readBoolean()) {
+                what = AEKey.readOptionalKey(buf);
+            }
+            long amount = buf.readVarLong();
+            boolean craftable = buf.readBoolean();
+            entries.add(new Entry(serial, what, amount, craftable));
+        }
+        return new SyncNetworkInventoryS2CPacket(fullUpdate, entries);
+    }
+
+    public static void handle(SyncNetworkInventoryS2CPacket msg, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            com.extendedae_plus.client.jei.NetworkItemCache.INSTANCE.handleUpdate(msg.fullUpdate, msg.entries);
+        });
+        ctx.get().setPacketHandled(true);
+    }
+
+    public boolean isFullUpdate() {
+        return fullUpdate;
+    }
+
+    public List<Entry> getEntries() {
+        return entries;
+    }
+
+    public static class Entry {
+        public final long serial;
+        public final AEKey what;
+        public final long amount;
+        public final boolean craftable;
+
+        public Entry(long serial, AEKey what, long amount, boolean craftable) {
+            this.serial = serial;
+            this.what = what;
+            this.amount = amount;
+            this.craftable = craftable;
+        }
+    }
+}

--- a/src/main/java/com/extendedae_plus/server/JeiSyncManager.java
+++ b/src/main/java/com/extendedae_plus/server/JeiSyncManager.java
@@ -1,0 +1,201 @@
+package com.extendedae_plus.server;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.crafting.ICraftingService;
+import appeng.api.networking.security.IActionHost;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.KeyCounter;
+import appeng.api.storage.MEStorage;
+import appeng.items.tools.powered.WirelessTerminalItem;
+import com.extendedae_plus.init.ModNetwork;
+import com.extendedae_plus.network.jei.SyncNetworkInventoryS2CPacket;
+import com.extendedae_plus.util.wireless.WirelessTerminalLocator;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.*;
+
+public class JeiSyncManager {
+
+    private static final int SYNC_INTERVAL_TICKS = 20;
+    private static final int MAX_ENTRIES_PER_PACKET = 8192;
+
+    private static final Map<UUID, PlayerSyncState> playerStates = new HashMap<>();
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        if (!(event.player instanceof ServerPlayer sp)) return;
+
+        UUID playerId = sp.getUUID();
+        PlayerSyncState state = playerStates.computeIfAbsent(playerId, k -> new PlayerSyncState());
+
+        state.tickCounter++;
+        if (state.tickCounter < SYNC_INTERVAL_TICKS) return;
+        state.tickCounter = 0;
+
+        var located = WirelessTerminalLocator.find(sp);
+        if (located == null || located.isEmpty()) {
+            if (state.wasConnected) {
+                sendClear(sp);
+                state.reset();
+            }
+            return;
+        }
+
+        IGrid grid = getGridFromTerminal(located, sp);
+        if (grid == null) {
+            if (state.wasConnected) {
+                sendClear(sp);
+                state.reset();
+            }
+            return;
+        }
+
+        MEStorage storage = grid.getStorageService().getInventory();
+        ICraftingService craftingService = grid.getCraftingService();
+
+        KeyCounter currentStacks = storage.getAvailableStacks();
+        Set<AEKey> currentCraftables = craftingService.getCraftables(key -> true);
+
+        // Build authoritative current state: amount snapshot + union of all present keys.
+        // A key is "present" if it has stock (>0) OR is craftable. getAvailableStacks()
+        // never holds zero-amount entries, so a fully-extracted-but-still-craftable item
+        // survives only via currentCraftables (with amount 0) -- it must NOT be treated as
+        // removed, and its amount drop must still be diffed.
+        Map<AEKey, Long> currentAmounts = new HashMap<>();
+        for (var entry : currentStacks) {
+            currentAmounts.put(entry.getKey(), entry.getLongValue());
+        }
+        Set<AEKey> currentKeys = new HashSet<>(currentAmounts.keySet());
+        currentKeys.addAll(currentCraftables);
+
+        boolean fullUpdate = !state.wasConnected;
+        List<SyncNetworkInventoryS2CPacket.Entry> entries = new ArrayList<>();
+
+        if (fullUpdate) {
+            state.serialMap.clear();
+            state.previousAmounts.clear();
+            state.previousCraftables.clear();
+            state.nextSerial = 1;
+
+            for (AEKey key : currentKeys) {
+                long amount = currentAmounts.getOrDefault(key, 0L);
+                boolean craftable = currentCraftables.contains(key);
+                long serial = state.nextSerial++;
+                state.serialMap.put(key, serial);
+                state.previousAmounts.put(key, amount);
+                if (craftable) state.previousCraftables.add(key);
+                entries.add(new SyncNetworkInventoryS2CPacket.Entry(serial, key, amount, craftable));
+            }
+        } else {
+            // Additions + changes: iterate the full union so amount->0 (still craftable)
+            // transitions are diffed instead of being silently dropped.
+            for (AEKey key : currentKeys) {
+                long amount = currentAmounts.getOrDefault(key, 0L);
+                boolean craftable = currentCraftables.contains(key);
+
+                Long serial = state.serialMap.get(key);
+                if (serial == null) {
+                    // new item
+                    serial = state.nextSerial++;
+                    state.serialMap.put(key, serial);
+                    state.previousAmounts.put(key, amount);
+                    if (craftable) state.previousCraftables.add(key);
+                    entries.add(new SyncNetworkInventoryS2CPacket.Entry(serial, key, amount, craftable));
+                } else {
+                    long prevAmount = state.previousAmounts.getOrDefault(key, 0L);
+                    boolean prevCraftable = state.previousCraftables.contains(key);
+                    if (prevAmount != amount || prevCraftable != craftable) {
+                        // changed amount or craftable status
+                        state.previousAmounts.put(key, amount);
+                        if (craftable) state.previousCraftables.add(key);
+                        else state.previousCraftables.remove(key);
+                        entries.add(new SyncNetworkInventoryS2CPacket.Entry(serial, null, amount, craftable));
+                    }
+                }
+            }
+
+            // removed items: in serialMap but no longer present (no stock and not craftable)
+            Iterator<Map.Entry<AEKey, Long>> it = state.serialMap.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<AEKey, Long> e = it.next();
+                AEKey key = e.getKey();
+                if (!currentKeys.contains(key)) {
+                    long serial = e.getValue();
+                    entries.add(new SyncNetworkInventoryS2CPacket.Entry(serial, null, 0, false));
+                    it.remove();
+                    state.previousAmounts.remove(key);
+                    state.previousCraftables.remove(key);
+                }
+            }
+        }
+
+        if (!entries.isEmpty()) {
+            // Send in chunks if too large
+            for (int i = 0; i < entries.size(); i += MAX_ENTRIES_PER_PACKET) {
+                int end = Math.min(i + MAX_ENTRIES_PER_PACKET, entries.size());
+                List<SyncNetworkInventoryS2CPacket.Entry> chunk = entries.subList(i, end);
+                boolean isFirst = (i == 0);
+                var packet = new SyncNetworkInventoryS2CPacket(fullUpdate && isFirst, chunk);
+                ModNetwork.CHANNEL.send(PacketDistributor.PLAYER.with(() -> sp), packet);
+            }
+        }
+
+        state.wasConnected = true;
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        playerStates.remove(event.getEntity().getUUID());
+    }
+
+    private static void sendClear(ServerPlayer sp) {
+        var packet = new SyncNetworkInventoryS2CPacket(true, Collections.emptyList());
+        ModNetwork.CHANNEL.send(PacketDistributor.PLAYER.with(() -> sp), packet);
+    }
+
+    private static IGrid getGridFromTerminal(WirelessTerminalLocator.LocatedTerminal located, ServerPlayer player) {
+        var stack = located.stack;
+        if (stack.isEmpty()) return null;
+
+        if (stack.getItem() instanceof WirelessTerminalItem wt) {
+            try {
+                var grid = wt.getLinkedGrid(stack, player.level(), player);
+                return grid != null ? grid : null;
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        // Try ae2wtlib/ExtendedAE wireless terminals
+        try {
+            if (stack.getItem() instanceof IActionHost actionHost) {
+                var node = actionHost.getActionableNode();
+                return node != null ? node.getGrid() : null;
+            }
+        } catch (Exception ignored) {}
+
+        return null;
+    }
+
+    private static class PlayerSyncState {
+        int tickCounter = 0;
+        boolean wasConnected = false;
+        long nextSerial = 1;
+        final Map<AEKey, Long> serialMap = new HashMap<>();
+        final Map<AEKey, Long> previousAmounts = new HashMap<>();
+        final Set<AEKey> previousCraftables = new HashSet<>();
+
+        void reset() {
+            wasConnected = false;
+            serialMap.clear();
+            previousAmounts.clear();
+            previousCraftables.clear();
+            nextSerial = 1;
+        }
+    }
+}

--- a/src/main/resources/extendedae_plus.mixins.json
+++ b/src/main/resources/extendedae_plus.mixins.json
@@ -32,6 +32,7 @@
     "extendedae.client.gui.GuiExPatternTerminalMixin",
     "jei.EncodePatternTransferHandlerMixin",
     "jei.EncodingHelperMixin",
+    "jei.IngredientListRendererMixin",
     "jei.accessor.BookmarkOverlayAccessor",
     "minecraft.ModelBakeryMixin",
     "minecraft.PickFromWirelessMixin",


### PR DESCRIPTION
## 简介

在 JEI 的物品列表 / 书签面板上，为每个物品叠加显示 AE2 网络中的**实时存量**（如 `128`、`1.2K`、`2.1G`）和**可合成标识**（`Craft` / `+`），视觉风格与 AE2 终端一致。

配合已有的 Shift+左键提取 / 中键请求合成功能，玩家现在无需点击就能一眼看到网络里有没有货、能不能合成。

## 效果演示

📺 视频演示：https://www.bilibili.com/video/BV1WX3J6ZEag

## 实现方式

参考 AE2 终端自身的同步机制（`MEStorageMenu` 的 serial + 增量 diff），做了轻量化改造：

- **服务端** `JeiSyncManager`：per-player 后台同步，每 20 tick 对 `getAvailableStacks()` + `getCraftables()` 做一次 diff，仅在玩家持有/装备有效无线终端（复用 `WirelessTerminalLocator`，支持 Curios）且在范围内有电时工作
- **网络包** `SyncNetworkInventoryS2CPacket`：复用 AE2 的 serial 协议，首次全量、之后增量，支持大网络分片
- **客户端** `NetworkItemCache`：按 serial 维护 `AEKey → (amount, craftable)` 映射，渲染时 O(1) 查询
- **渲染** `IngredientListRendererMixin`：注入 JEI `IngredientListRenderer.render()` 尾部叠加绘制，通过 `MixinConditions` 确保仅在 JEI 存在时加载

相比 AE2 终端本身，同步频率低 20 倍、客户端不做排序/过滤，开销完全可控。

## 说明

- 仅同步 `ItemStack`，暂不含流体/化学品
- 终端离线/失效时自动清空叠加显示，不残留过期数据