### PR TITLE
[Documentation] incorrect "smelter" wording in English ae2guide

### DIFF
--- a/src/main/resources/assets/extendedae_plus/ae2guide/introduction/devices/assembler_matrix_upload_core.md
+++ b/src/main/resources/assets/extendedae_plus/ae2guide/introduction/devices/assembler_matrix_upload_core.md
@@ -18,7 +18,7 @@ The **Assembler Matrix Upload Core** is a functional module that adds the abilit
 
 ## Feature Overview
 
-When installed in an Assembler Matrix, patterns created in the Pattern Encoding Terminal — including **crafting patterns**, **smelter patterns**, or **stonecutter patterns** — are automatically uploaded into the Assembler Matrix storage without manual transfer.
+When installed in an Assembler Matrix, patterns created in the Pattern Encoding Terminal — including **crafting patterns**, **smithing table patterns**, or **stonecutter patterns** — are automatically uploaded into the Assembler Matrix storage without manual transfer.
 
 ## Version History & Important Changes
 

--- a/src/main/resources/assets/extendedae_plus/ae2guide/introduction/features/features.md
+++ b/src/main/resources/assets/extendedae_plus/ae2guide/introduction/features/features.md
@@ -100,7 +100,7 @@ A multiplication control button is added in the pattern provider GUI, allowing p
 
 ### 1. Fast Pattern Upload
 
-- **Auto-detect Assembly Matrix:** If an assembly matrix exists in the network, patterns completed in the Pattern Encoding Terminal (for crafting, smelting, or cutting) are automatically uploaded. Existing identical patterns are detected and returned, avoiding duplicates.(The Shift key must be pressed when clicking the encoding button.)  
+- **Auto-detect Assembly Matrix:** If an assembly matrix exists in the network, patterns completed in the Pattern Encoding Terminal (for crafting, smithing, or cutting) are automatically uploaded. Existing identical patterns are detected and returned, avoiding duplicates.(The Shift key must be pressed when clicking the encoding button.)  
 
 <br/>
 


### PR DESCRIPTION
## Summary
Fixes incorrect wording in the English `ae2guide` documentation for the **Assembler Matrix Upload Core**. The docs referred to supported pattern types as `smelter`/`smelting` patterns, which does not match the actual supported types (Crafting, **Smithing Table**, Stonecutting) handled in `MatrixUploadUtil.java`.

## Background
Closes #109

The Chinese (`zh_cn`) version of the same docs already used the correct term (`锻造台样板` / smithing table pattern), so only the English docs needed correction.

## Changes
- `src/main/resources/assets/extendedae_plus/ae2guide/introduction/devices/assembler_matrix_upload_core.md`: `smelter patterns` → `smithing table patterns`
- `src/main/resources/assets/extendedae_plus/ae2guide/introduction/features/features.md`: `smelting` → `smithing`
