### PR TITLE
fix: CTRL+Q 按键判定与有序配方槽位还原

### DIFF
--- a/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
+++ b/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
@@ -47,7 +47,9 @@ public final class CtrlQPatternKeyHandler {
 		int scanCode = event.getScanCode();
 		boolean isAllowSubstitutes = Screen.hasShiftDown();
 		boolean isFluidSubstitutes = Screen.hasAltDown();
-		if (!ModKeybindings.CREATE_PATTERN_KEY.matches(keyCode, scanCode)) {
+		// isActiveAndMatches 才会校验修饰键（Ctrl）与冲突上下文；KeyMapping.matches 对裸键也会命中
+		if (!ModKeybindings.CREATE_PATTERN_KEY.isActiveAndMatches(
+				com.mojang.blaze3d.platform.InputConstants.Type.KEYSYM.getOrCreate(keyCode))) {
 			return;
 		}
 

--- a/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
+++ b/src/main/java/com/extendedae_plus/client/event/CtrlQPatternKeyHandler.java
@@ -9,6 +9,7 @@ import com.extendedae_plus.network.CreateCtrlQPatternC2SPacket;
 import com.extendedae_plus.util.RecipeFinderUtil;
 import com.extendedae_plus.util.RecipeInfo;
 import com.extendedae_plus.util.uploadPattern.ExtendedAEPatternUploadUtil;
+import com.mojang.blaze3d.platform.InputConstants;
 import mezz.jei.api.constants.RecipeTypes;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.ingredients.ITypedIngredient;
@@ -49,7 +50,7 @@ public final class CtrlQPatternKeyHandler {
 		boolean isFluidSubstitutes = Screen.hasAltDown();
 		// isActiveAndMatches 才会校验修饰键（Ctrl）与冲突上下文；KeyMapping.matches 对裸键也会命中
 		if (!ModKeybindings.CREATE_PATTERN_KEY.isActiveAndMatches(
-				com.mojang.blaze3d.platform.InputConstants.Type.KEYSYM.getOrCreate(keyCode))) {
+				InputConstants.Type.KEYSYM.getOrCreate(keyCode))) {
 			return;
 		}
 

--- a/src/main/java/com/extendedae_plus/client/event/EmiCtrlQHandler.java
+++ b/src/main/java/com/extendedae_plus/client/event/EmiCtrlQHandler.java
@@ -9,6 +9,7 @@ import com.extendedae_plus.network.CreateAndUploadPatternC2SPacket;
 import com.extendedae_plus.network.CreateCtrlQPatternC2SPacket;
 import com.extendedae_plus.util.RecipeFinderUtil;
 import com.extendedae_plus.util.RecipeInfo;
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
@@ -41,7 +42,7 @@ public final class EmiCtrlQHandler {
 		}
 		// isActiveAndMatches 才会校验修饰键（Ctrl）与冲突上下文；KeyMapping.matches 对裸键也会命中
 		if (!ModKeybindings.CREATE_PATTERN_KEY.isActiveAndMatches(
-				com.mojang.blaze3d.platform.InputConstants.Type.KEYSYM.getOrCreate(event.getKeyCode()))) {
+				InputConstants.Type.KEYSYM.getOrCreate(event.getKeyCode()))) {
 			return;
 		}
 		// 双查看器仲裁：EMI 在场时本类接管，JEI 分支让位（与 InputEvents 的分派优先级一致）。

--- a/src/main/java/com/extendedae_plus/client/event/EmiCtrlQHandler.java
+++ b/src/main/java/com/extendedae_plus/client/event/EmiCtrlQHandler.java
@@ -39,7 +39,9 @@ public final class EmiCtrlQHandler {
 		if (screen == null) {
 			return;
 		}
-		if (!ModKeybindings.CREATE_PATTERN_KEY.matches(event.getKeyCode(), event.getScanCode())) {
+		// isActiveAndMatches 才会校验修饰键（Ctrl）与冲突上下文；KeyMapping.matches 对裸键也会命中
+		if (!ModKeybindings.CREATE_PATTERN_KEY.isActiveAndMatches(
+				com.mojang.blaze3d.platform.InputConstants.Type.KEYSYM.getOrCreate(event.getKeyCode()))) {
 			return;
 		}
 		// 双查看器仲裁：EMI 在场时本类接管，JEI 分支让位（与 InputEvents 的分派优先级一致）。

--- a/src/main/java/com/extendedae_plus/compat/EmiRecipeCompat.java
+++ b/src/main/java/com/extendedae_plus/compat/EmiRecipeCompat.java
@@ -72,9 +72,30 @@ public final class EmiRecipeCompat {
 		}
 
 		List<List<GenericStack>> inputs;
-		if (crafting && holderOpt.get().value() instanceof CraftingRecipe craftingRecipe) {
+		if (crafting && holderOpt.get().value() instanceof net.minecraft.world.item.crafting.ShapedRecipe shaped) {
+			// 有序配方：getIngredients() 是宽×高的紧凑行主序，必须按宽度还原到 3x3 的真实槽位
+			// （如 1x3 竖条形的材料应位于槽位 0,3,6），否则 AE2 解码时 matches() 复验失败 → 无效样板。
+			var ingredients = shaped.getIngredients();
+			int width = Math.max(1, shaped.getWidth());
+			List<List<GenericStack>> grid = new ArrayList<>(9);
+			for (int i = 0; i < 9; i++) {
+				grid.add(new ArrayList<>());
+			}
+			for (int i = 0; i < ingredients.size() && i < 9; i++) {
+				int slot = (i / width) * 3 + (i % width);
+				ItemStack[] items = ingredients.get(i).getItems();
+				if (items.length > 0 && !items[0].isEmpty()) {
+					GenericStack gs = GenericStack.fromItemStack(items[0].copy());
+					if (gs != null) {
+						grid.get(slot).add(gs);
+					}
+				}
+			}
+			inputs = grid;
+		} else if (crafting) {
+			// 无序合成：顺序无关，紧凑填充即可
 			inputs = new ArrayList<>();
-			for (var ingredient : craftingRecipe.getIngredients()) {
+			for (var ingredient : ((CraftingRecipe) holderOpt.get().value()).getIngredients()) {
 				List<GenericStack> candidates = new ArrayList<>();
 				ItemStack[] items = ingredient.getItems();
 				if (items.length > 0 && !items[0].isEmpty()) {

--- a/src/main/java/com/extendedae_plus/compat/EmiRecipeCompat.java
+++ b/src/main/java/com/extendedae_plus/compat/EmiRecipeCompat.java
@@ -11,6 +11,7 @@ import dev.emi.emi.api.stack.EmiStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 
@@ -72,7 +73,7 @@ public final class EmiRecipeCompat {
 		}
 
 		List<List<GenericStack>> inputs;
-		if (crafting && holderOpt.get().value() instanceof net.minecraft.world.item.crafting.ShapedRecipe shaped) {
+		if (crafting && holderOpt.get().value() instanceof ShapedRecipe shaped) {
 			// 有序配方：getIngredients() 是宽×高的紧凑行主序，必须按宽度还原到 3x3 的真实槽位
 			// （如 1x3 竖条形的材料应位于槽位 0,3,6），否则 AE2 解码时 matches() 复验失败 → 无效样板。
 			var ingredients = shaped.getIngredients();


### PR DESCRIPTION
基于 `1.21.1`（892bfdf8）的 1 个提交。原 #127 拆分出的第 1 部分，可独立合并。

### CTRL+Q 按键判定改用 `isActiveAndMatches`

`KeyMapping.matches(keyCode, scanCode)` 只比对键位本身，不校验修饰键，也不看冲突上下文——结果是单独按 Q 就会触发编码样板，而这个功能本该是 CTRL+Q。改成 `isActiveAndMatches(InputConstants.Type.KEYSYM.getOrCreate(keyCode))`，修饰键与按键冲突上下文都会参与判定。

JEI 路径（`CtrlQPatternKeyHandler`）与 EMI 路径（`EmiCtrlQHandler`）各有一处，两边都改了。

### 有序配方还原到 3x3 真实槽位

`ShapedRecipe#getIngredients()` 返回的是 **宽×高的紧凑行主序**，不是 3x3 的槽位序列。1x3 竖条形配方的三个材料在列表里是索引 0/1/2，但在合成网格上应落在槽位 0/3/6。原先直接按列表顺序填槽，编出来的样板 AE2 解码时 `matches()` 复验失败，得到无效样板。

现按 `slot = (i / width) * 3 + (i % width)` 还原到真实槽位，并补齐 9 格（含空槽）。无序合成（`ShapelessRecipe` 等）顺序无关，仍走紧凑填充分支。

---

测试：`./gradlew build`（JDK 21）通过。仓库无测试源码。
