### PR TITLE
feat: 批量编码上传的服务端路径与全网重复样板检测

### DIFF
--- a/src/main/java/com/extendedae_plus/init/ModNetwork.java
+++ b/src/main/java/com/extendedae_plus/init/ModNetwork.java
@@ -1,6 +1,7 @@
 package com.extendedae_plus.init;
 
 import com.extendedae_plus.ExtendedAEPlus;
+import com.extendedae_plus.network.BatchCreateAndUploadPatternC2SPacket;
 import com.extendedae_plus.network.CancelPendingPatternC2SPacket;
 import com.extendedae_plus.network.CraftingMonitorJumpC2SPacket;
 import com.extendedae_plus.network.CraftingMonitorOpenProviderC2SPacket;
@@ -52,6 +53,7 @@ public class ModNetwork {
         registrar.playToServer(UploadInventoryPatternToProviderC2SPacket.TYPE, UploadInventoryPatternToProviderC2SPacket.STREAM_CODEC, UploadInventoryPatternToProviderC2SPacket::handle);
         registrar.playToServer(CreateCtrlQPatternC2SPacket.TYPE, CreateCtrlQPatternC2SPacket.STREAM_CODEC, CreateCtrlQPatternC2SPacket::handle);
         registrar.playToServer(CreateAndUploadPatternC2SPacket.TYPE, CreateAndUploadPatternC2SPacket.STREAM_CODEC, CreateAndUploadPatternC2SPacket::handle);
+        registrar.playToServer(BatchCreateAndUploadPatternC2SPacket.TYPE, BatchCreateAndUploadPatternC2SPacket.STREAM_CODEC, BatchCreateAndUploadPatternC2SPacket::handle);
         registrar.playToServer(CancelPendingPatternC2SPacket.TYPE,CancelPendingPatternC2SPacket.STREAM_CODEC,CancelPendingPatternC2SPacket::handle);
         registrar.playToServer(EncodeWithShiftFlagC2SPacket.TYPE, EncodeWithShiftFlagC2SPacket.STREAM_CODEC, EncodeWithShiftFlagC2SPacket::handle);
         // 新增：JEI 中键打开合成界面 & 无线终端拾取方块物品

--- a/src/main/java/com/extendedae_plus/network/BatchCreateAndUploadPatternC2SPacket.java
+++ b/src/main/java/com/extendedae_plus/network/BatchCreateAndUploadPatternC2SPacket.java
@@ -4,6 +4,7 @@ import appeng.api.networking.IGrid;
 import appeng.helpers.patternprovider.PatternContainer;
 import com.extendedae_plus.ExtendedAEPlus;
 import com.extendedae_plus.util.uploadPattern.CtrlQPendingUploadUtil;
+import com.extendedae_plus.util.uploadPattern.BatchPatternUploadUtil;
 import com.extendedae_plus.util.uploadPattern.ExtendedAEPatternUploadUtil;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -108,7 +109,7 @@ public class BatchCreateAndUploadPatternC2SPacket implements CustomPacketPayload
 			// 供应器列表整批复用一次快照：逐个查会在大树上重复遍历整个网络的机器类。
 			List<PatternContainer> providers = CtrlQPendingUploadUtil.listAvailableProvidersFromPlayerNetwork(player);
 			// 已存在样板集合同样只建一次：逐个样板扫全网是 O(样板数 × 供应器数 × 槽位数)。
-			Set<ItemStack> existingPatterns = ExtendedAEPatternUploadUtil.collectExistingPatterns(grid, providers);
+			Set<ItemStack> existingPatterns = BatchPatternUploadUtil.collectExistingPatterns(grid, providers);
 
 			int toMatrix = 0;
 			int toProvider = 0;
@@ -141,7 +142,7 @@ public class BatchCreateAndUploadPatternC2SPacket implements CustomPacketPayload
 				}
 
 				// 反复按一键编码时不该在网络里堆一摞重复样板：装配矩阵与供应器都算已存在。
-				if (ExtendedAEPatternUploadUtil.containsPattern(existingPatterns, pattern)) {
+				if (BatchPatternUploadUtil.containsPattern(existingPatterns, pattern)) {
 					duplicate++;
 					continue;
 				}
@@ -153,21 +154,21 @@ public class BatchCreateAndUploadPatternC2SPacket implements CustomPacketPayload
 
 				// 装配矩阵只收合成/锻造/切石样板，处理样板必然落到下一段。
 				if (ExtendedAEPatternUploadUtil.uploadPatternToMatrix(player, pattern, grid, true)) {
-					ExtendedAEPatternUploadUtil.rememberPattern(existingPatterns, pattern);
+					BatchPatternUploadUtil.rememberPattern(existingPatterns, pattern);
 					toMatrix++;
 					continue;
 				}
 
-				if (ExtendedAEPatternUploadUtil.uploadPatternToMatchingProvider(
+				if (BatchPatternUploadUtil.uploadPatternToMatchingProvider(
 						player, pattern, providers, entry.providerSearchKey())) {
-					ExtendedAEPatternUploadUtil.rememberPattern(existingPatterns, pattern);
+					BatchPatternUploadUtil.rememberPattern(existingPatterns, pattern);
 					toProvider++;
 					continue;
 				}
 
 				// 落背包的也登记：服务端不能依赖客户端已按配方去重，
 				// 否则一个塞满同一条目的封包会白扣掉整叠空白样板。
-				ExtendedAEPatternUploadUtil.rememberPattern(existingPatterns, pattern);
+				BatchPatternUploadUtil.rememberPattern(existingPatterns, pattern);
 				if (!player.getInventory().add(pattern)) {
 					player.drop(pattern.copy(), false);
 				}

--- a/src/main/java/com/extendedae_plus/network/BatchCreateAndUploadPatternC2SPacket.java
+++ b/src/main/java/com/extendedae_plus/network/BatchCreateAndUploadPatternC2SPacket.java
@@ -1,0 +1,203 @@
+package com.extendedae_plus.network;
+
+import appeng.api.networking.IGrid;
+import appeng.helpers.patternprovider.PatternContainer;
+import com.extendedae_plus.ExtendedAEPlus;
+import com.extendedae_plus.util.uploadPattern.CtrlQPendingUploadUtil;
+import com.extendedae_plus.util.uploadPattern.ExtendedAEPatternUploadUtil;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * C2S: 合成链（EMI 配方树 / BoM）一键批量编码并上传。
+ * <p>
+ * 相比逐个发送 {@link CreateAndUploadPatternC2SPacket}，本封包一次带走整棵树：
+ * 服务端只查一次网络与供应器列表，逐个样板按「装配矩阵 → 依映射匹配的供应器 → 背包」三段回退，
+ * 最后只回一条汇总消息（避免 N 个节点刷 N 条聊天）。
+ * <p>
+ * {@code providerSearchKey} 由客户端依据自己的 {@code recipe_type_names.json} 解析后传入：
+ * 映射表由客户端的映射管理界面维护，服务端那份对本流程无作用，
+ * 若改为服务端解析会导致合成树上的映射标记与实际上传目标不一致。
+ */
+public class BatchCreateAndUploadPatternC2SPacket implements CustomPacketPayload {
+	public static final Type<BatchCreateAndUploadPatternC2SPacket> TYPE = new Type<>(
+		ResourceLocation.fromNamespaceAndPath(ExtendedAEPlus.MODID, "batch_create_and_upload_pattern"));
+
+	/** 单封包条目上限，客户端超出时自行分批发送。 */
+	public static final int MAX_ENTRIES = 64;
+
+	/**
+	 * @param providerSearchKey 映射出的供应器搜索词；空串表示该配方类型没有自定义映射。
+	 */
+	public record Entry(
+		ResourceLocation recipeId,
+		boolean isCraftingPattern,
+		List<ItemStack> selectedIngredients,
+		List<ItemStack> outputs,
+		String providerSearchKey
+	) {}
+
+	public static final StreamCodec<RegistryFriendlyByteBuf, BatchCreateAndUploadPatternC2SPacket> STREAM_CODEC =
+		StreamCodec.of(
+			(buf, pkt) -> {
+				buf.writeBoolean(pkt.isAllowSubstitutes);
+				buf.writeBoolean(pkt.isFluidSubstitutes);
+				buf.writeVarInt(pkt.entries.size());
+				for (Entry entry : pkt.entries) {
+					buf.writeResourceLocation(entry.recipeId());
+					buf.writeBoolean(entry.isCraftingPattern());
+					ItemStack.OPTIONAL_LIST_STREAM_CODEC.encode(buf, entry.selectedIngredients());
+					ItemStack.OPTIONAL_LIST_STREAM_CODEC.encode(buf, entry.outputs());
+					buf.writeUtf(entry.providerSearchKey() == null ? "" : entry.providerSearchKey());
+				}
+			},
+			buf -> {
+				boolean isAllowSubstitutes = buf.readBoolean();
+				boolean isFluidSubstitutes = buf.readBoolean();
+				int count = Math.min(buf.readVarInt(), MAX_ENTRIES);
+				List<Entry> entries = new ArrayList<>(count);
+				for (int i = 0; i < count; i++) {
+					ResourceLocation recipeId = buf.readResourceLocation();
+					boolean isCraftingPattern = buf.readBoolean();
+					List<ItemStack> ingredients = ItemStack.OPTIONAL_LIST_STREAM_CODEC.decode(buf);
+					List<ItemStack> outputs = ItemStack.OPTIONAL_LIST_STREAM_CODEC.decode(buf);
+					String searchKey = buf.readUtf();
+					entries.add(new Entry(recipeId, isCraftingPattern, ingredients, outputs, searchKey));
+				}
+				return new BatchCreateAndUploadPatternC2SPacket(entries, isAllowSubstitutes, isFluidSubstitutes);
+			}
+		);
+
+	private final List<Entry> entries;
+	private final boolean isAllowSubstitutes;
+	private final boolean isFluidSubstitutes;
+
+	public BatchCreateAndUploadPatternC2SPacket(List<Entry> entries,
+	                                            boolean isAllowSubstitutes,
+	                                            boolean isFluidSubstitutes) {
+		this.entries = entries;
+		this.isAllowSubstitutes = isAllowSubstitutes;
+		this.isFluidSubstitutes = isFluidSubstitutes;
+	}
+
+	public static void handle(final BatchCreateAndUploadPatternC2SPacket msg, final IPayloadContext ctx) {
+		ctx.enqueueWork(() -> {
+			if (!(ctx.player() instanceof ServerPlayer player)) {
+				return;
+			}
+			if (msg.entries.isEmpty()) {
+				return;
+			}
+
+			IGrid grid = CtrlQPendingUploadUtil.findPlayerGrid(player);
+			if (grid == null) {
+				player.displayClientMessage(Component.translatable("message.extendedae_plus.no_network"), false);
+				return;
+			}
+
+			// 供应器列表整批复用一次快照：逐个查会在大树上重复遍历整个网络的机器类。
+			List<PatternContainer> providers = CtrlQPendingUploadUtil.listAvailableProvidersFromPlayerNetwork(player);
+			// 已存在样板集合同样只建一次：逐个样板扫全网是 O(样板数 × 供应器数 × 槽位数)。
+			Set<ItemStack> existingPatterns = ExtendedAEPatternUploadUtil.collectExistingPatterns(grid, providers);
+
+			int toMatrix = 0;
+			int toProvider = 0;
+			int toInventory = 0;
+			int noRecipe = 0;
+			int duplicate = 0;
+			int failed = 0;
+			boolean outOfBlankPatterns = false;
+
+			for (Entry entry : msg.entries) {
+				var recipeOpt = player.level().getRecipeManager().byKey(entry.recipeId());
+				if (recipeOpt.isEmpty()) {
+					noRecipe++;
+					continue;
+				}
+
+				// 先编码再扣空白样板：编码本身不消耗材料，这样重复项与编码失败都不会白扣。
+				ItemStack pattern = CreateAndUploadPatternC2SPacket.encodePattern(
+					recipeOpt.get(),
+					entry.isCraftingPattern(),
+					entry.selectedIngredients(),
+					entry.outputs(),
+					msg.isAllowSubstitutes,
+					msg.isFluidSubstitutes,
+					player
+				);
+				if (pattern.isEmpty()) {
+					failed++;
+					continue;
+				}
+
+				// 反复按一键编码时不该在网络里堆一摞重复样板：装配矩阵与供应器都算已存在。
+				if (ExtendedAEPatternUploadUtil.containsPattern(existingPatterns, pattern)) {
+					duplicate++;
+					continue;
+				}
+
+				if (!CreateAndUploadPatternC2SPacket.consumeBlankPattern(player, grid)) {
+					outOfBlankPatterns = true;
+					break;
+				}
+
+				// 装配矩阵只收合成/锻造/切石样板，处理样板必然落到下一段。
+				if (ExtendedAEPatternUploadUtil.uploadPatternToMatrix(player, pattern, grid, true)) {
+					ExtendedAEPatternUploadUtil.rememberPattern(existingPatterns, pattern);
+					toMatrix++;
+					continue;
+				}
+
+				if (ExtendedAEPatternUploadUtil.uploadPatternToMatchingProvider(
+						player, pattern, providers, entry.providerSearchKey())) {
+					ExtendedAEPatternUploadUtil.rememberPattern(existingPatterns, pattern);
+					toProvider++;
+					continue;
+				}
+
+				// 落背包的也登记：服务端不能依赖客户端已按配方去重，
+				// 否则一个塞满同一条目的封包会白扣掉整叠空白样板。
+				ExtendedAEPatternUploadUtil.rememberPattern(existingPatterns, pattern);
+				if (!player.getInventory().add(pattern)) {
+					player.drop(pattern.copy(), false);
+				}
+				toInventory++;
+			}
+
+			player.displayClientMessage(Component.translatable(
+				"message.extendedae_plus.bom_encode.summary",
+				toMatrix, toProvider, toInventory), false);
+
+			if (duplicate > 0) {
+				player.displayClientMessage(Component.translatable(
+					"message.extendedae_plus.bom_encode.skipped_duplicate", duplicate), false);
+			}
+			if (noRecipe > 0) {
+				player.displayClientMessage(Component.translatable(
+					"message.extendedae_plus.bom_encode.skipped_no_recipe", noRecipe), false);
+			}
+			if (failed > 0) {
+				player.displayClientMessage(Component.translatable(
+					"message.extendedae_plus.bom_encode.failed", failed), false);
+			}
+			if (outOfBlankPatterns) {
+				player.displayClientMessage(Component.translatable("message.extendedae_plus.no_blank_pattern"), false);
+			}
+		});
+	}
+
+	@Override
+	public Type<? extends CustomPacketPayload> type() {
+		return TYPE;
+	}
+}

--- a/src/main/java/com/extendedae_plus/network/CreateAndUploadPatternC2SPacket.java
+++ b/src/main/java/com/extendedae_plus/network/CreateAndUploadPatternC2SPacket.java
@@ -118,7 +118,7 @@ public class CreateAndUploadPatternC2SPacket implements CustomPacketPayload {
 				return;
 			}
 
-			ItemStack pattern = createPattern(
+			ItemStack pattern = encodePattern(
 				recipeHolder,
 				msg.isCraftingPattern,
 				msg.selectedIngredients,
@@ -147,7 +147,8 @@ public class CreateAndUploadPatternC2SPacket implements CustomPacketPayload {
 		return TYPE;
 	}
 
-	private static boolean consumeBlankPattern(ServerPlayer player, IGrid grid) {
+	// 包内可见：批量分支（BatchCreateAndUploadPatternC2SPacket）复用同一套空白样板与编码逻辑。
+	static boolean consumeBlankPattern(ServerPlayer player, IGrid grid) {
 		AEItemKey blankPatternKey = AEItemKey.of(AEItems.BLANK_PATTERN.stack());
 		IEnergyService energy = grid.getEnergyService();
 		MEStorage storage = grid.getStorageService().getInventory();
@@ -162,7 +163,7 @@ public class CreateAndUploadPatternC2SPacket implements CustomPacketPayload {
 		return extracted > 0;
 	}
 
-	private static void refundBlankPattern(ServerPlayer player, IGrid grid) {
+	static void refundBlankPattern(ServerPlayer player, IGrid grid) {
 		AEItemKey blankPatternKey = AEItemKey.of(AEItems.BLANK_PATTERN.stack());
 		IEnergyService energy = grid.getEnergyService();
 		MEStorage storage = grid.getStorageService().getInventory();
@@ -175,7 +176,8 @@ public class CreateAndUploadPatternC2SPacket implements CustomPacketPayload {
 		);
 	}
 
-	private static ItemStack createPattern(
+	// 包内可见：批量分支（BatchCreateAndUploadPatternC2SPacket）复用同一套编码逻辑。
+	static ItemStack encodePattern(
 		RecipeHolder<?> recipeHolder,
 		boolean isCrafting,
 		List<ItemStack> selectedIngredients,

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/BatchPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/BatchPatternUploadUtil.java
@@ -1,0 +1,234 @@
+package com.extendedae_plus.util.uploadPattern;
+
+import appeng.api.crafting.PatternDetailsHelper;
+import appeng.api.inventories.InternalInventory;
+import appeng.api.networking.IGrid;
+import appeng.helpers.patternprovider.PatternContainer;
+import com.extendedae_plus.util.uploadPattern.ExtendedAEPatternUploadUtil.MatrixInventoryTarget;
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 批量编码上传专用的工具：全网重复样板检测、依映射挑供应器插入。
+ * <p>
+ * 与单个样板上传共用的部分（空白样板扣减、编码、矩阵插入）仍在
+ * {@link ExtendedAEPatternUploadUtil}；这里只放批量路径独有的逻辑，
+ * 避免把那个本就很大的共享工具类继续撑大。
+ */
+public final class BatchPatternUploadUtil {
+
+	private BatchPatternUploadUtil() {}
+
+	// --------------------------- 重复样板检测 ---------------------------
+
+	/**
+	 * 忽略编码者信息后的样板副本，用于判定「是不是同一份样板」。
+	 * {@code encodePlayer} 只记录是谁编的，不影响样板功能，必须排除在比较之外。
+	 */
+	private static ItemStack normalizePatternForCompare(ItemStack pattern) {
+		ItemStack copy = pattern.copy();
+		CompoundTag tag = copy.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.of(new CompoundTag())).copyTag();
+		tag.remove("encodePlayer");
+		copy.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+		return copy;
+	}
+
+	/** 建立「忽略编码者」的样板集合：元素一律先经 {@link #normalizePatternForCompare} 规范化。 */
+	private static Set<ItemStack> newPatternSet() {
+		return new ObjectOpenCustomHashSet<>(new Hash.Strategy<>() {
+			@Override
+			public int hashCode(ItemStack stack) {
+				return stack == null ? 0 : ItemStack.hashItemAndComponents(stack);
+			}
+
+			@Override
+			public boolean equals(ItemStack a, ItemStack b) {
+				return a == b || (a != null && b != null && ItemStack.isSameItemSameComponents(a, b));
+			}
+		});
+	}
+
+	/**
+	 * 收集网络中已存在的样板（装配矩阵 + 样板供应器），供批量编码一次性查重。
+	 * <p>
+	 * 批量编码若逐个样板扫全网，复杂度是 O(样板数 × 供应器数 × 槽位数)，
+	 * 大网络上足以造成明显卡顿；因此扫一遍建成哈希集合，之后每次查重都是 O(1)。
+	 * 新放进去的样板要由调用方 {@link #rememberPattern} 补进集合，集合不会自动跟随库存变化。
+	 *
+	 * @param providers 供应器快照；传 null 表示只看装配矩阵
+	 */
+	public static Set<ItemStack> collectExistingPatterns(IGrid grid, List<PatternContainer> providers) {
+		Set<ItemStack> existing = newPatternSet();
+		if (grid == null) {
+			return existing;
+		}
+
+		try {
+			for (MatrixInventoryTarget target : ExtendedAEPatternUploadUtil.findAllMatrixPatternInventories(grid)) {
+				InternalInventory inv = target == null ? null : target.patternInventory();
+				collectFrom(inv, inv == null ? 0 : inv.size(), existing);
+			}
+		} catch (Throwable ignored) {
+		}
+
+		if (providers != null) {
+			for (PatternContainer container : providers) {
+				if (container == null) continue;
+				try {
+					collectFrom(container.getTerminalPatternInventory(),
+							ExtendedAEPatternUploadUtil.getAccessiblePatternSlotCount(container), existing);
+				} catch (Throwable ignored) {
+				}
+			}
+		}
+		return existing;
+	}
+
+	private static void collectFrom(InternalInventory inv, int slotLimit, Set<ItemStack> out) {
+		if (inv == null) {
+			return;
+		}
+		int limit = Math.max(0, Math.min(inv.size(), slotLimit));
+		for (int i = 0; i < limit; i++) {
+			ItemStack stack = inv.getStackInSlot(i);
+			if (stack != null && !stack.isEmpty() && PatternDetailsHelper.isEncodedPattern(stack)) {
+				out.add(normalizePatternForCompare(stack));
+			}
+		}
+	}
+
+	/** 集合里是否已有这份样板。 */
+	public static boolean containsPattern(Set<ItemStack> existing, ItemStack pattern) {
+		if (existing == null || existing.isEmpty() || pattern == null || pattern.isEmpty()) {
+			return false;
+		}
+		return existing.contains(normalizePatternForCompare(pattern));
+	}
+
+	/** 样板成功放入网络后登记进集合，让同一批里的后续项也能查到。 */
+	public static void rememberPattern(Set<ItemStack> existing, ItemStack pattern) {
+		if (existing == null || pattern == null || pattern.isEmpty()) {
+			return;
+		}
+		existing.add(normalizePatternForCompare(pattern));
+	}
+
+	// --------------------------- 依映射挑供应器 ---------------------------
+
+	// 优先使用 JEC 的拼音匹配，否则回退到大小写不敏感子串匹配
+	private static Boolean JEC_AVAILABLE = null;
+	private static java.lang.reflect.Method JEC_CONTAINS = null;
+
+	/**
+	 * 供应器名称与搜索词的匹配（客户端选择界面与服务端定向上传共用同一语义）。
+	 * 空搜索词视为全部匹配。
+	 */
+	public static boolean providerNameMatches(String name, String key) {
+		if (name == null) return false;
+		if (key == null || key.isEmpty()) return true;
+		try {
+			if (JEC_AVAILABLE == null) {
+				try {
+					Class<?> cls = Class.forName("me.towdium.jecharacters.utils.Match");
+					// 使用 contains(CharSequence, CharSequence)
+					JEC_CONTAINS = cls.getMethod("contains", CharSequence.class, CharSequence.class);
+					JEC_AVAILABLE = true;
+				} catch (Throwable t) {
+					JEC_AVAILABLE = false;
+				}
+			}
+			if (Boolean.TRUE.equals(JEC_AVAILABLE) && JEC_CONTAINS != null) {
+				Object r = JEC_CONTAINS.invoke(null, name, key);
+				if (r instanceof Boolean && (Boolean) r) return true;
+				// 再尝试大小写不敏感：双方转为小写重新匹配
+				String nL = name.toLowerCase();
+				String kL = key.toLowerCase();
+				Object r2 = JEC_CONTAINS.invoke(null, nL, kL);
+				if (r2 instanceof Boolean && (Boolean) r2) return true;
+			}
+		} catch (Throwable ignored) {
+			// 回退
+		}
+		// 默认大小写不敏感子串
+		return name.toLowerCase().contains(key.toLowerCase());
+	}
+
+	/**
+	 * 依映射搜索词在给定供应器列表中寻找名称匹配者并插入样板。
+	 * 空位多的优先，避免把整棵树的样板全挤到同一台机器上。
+	 * 批量上传专用：不记录 last uploaded provider（一批 N 个样板的“最后一个”没有意义）。
+	 */
+	public static boolean uploadPatternToMatchingProvider(ServerPlayer player,
+	                                                     ItemStack pattern,
+	                                                     List<PatternContainer> providers,
+	                                                     String searchKey) {
+		if (player == null || pattern == null || pattern.isEmpty()
+				|| searchKey == null || searchKey.isBlank()
+				|| providers == null || providers.isEmpty()) {
+			return false;
+		}
+
+		List<PatternContainer> matched = new ArrayList<>();
+		for (PatternContainer container : providers) {
+			if (container == null) continue;
+			if (providerNameMatches(
+					ExtendedAEPatternUploadUtil.getProviderDisplayNameComponent(container).getString(), searchKey)) {
+				matched.add(container);
+			}
+		}
+		if (matched.isEmpty()) {
+			return false;
+		}
+		// getAvailableSlots 有重载，方法引用无法在 reversed() 处推断类型，显式声明比较器元素类型。
+		Comparator<PatternContainer> bySlotsDesc = Comparator.comparingInt(
+				(PatternContainer c) -> ExtendedAEPatternUploadUtil.getAvailableSlots(c)).reversed();
+		matched.sort(bySlotsDesc);
+
+		// 查重不在这里做：会把「已存在」和「插不进去」混成同一个 false，
+		// 导致调用方误判为失败而把样板塞进背包。查重由调用方在尝试上传前用
+		// collectExistingPatterns 一次性完成。
+		for (PatternContainer container : matched) {
+			ItemStack remain = ExtendedAEPatternUploadUtil
+					.insertIntoAccessiblePatternSlots(container, pattern.copy(), null);
+			if (remain.isEmpty()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * 列出网络中所有终端可见的样板供应器（不筛空位）。
+	 * 供“为配方类型挑选机器建立映射”使用：映射只关心名字，机器当下满不满无关。
+	 */
+	public static List<PatternContainer> listAllProvidersFromGrid(IGrid grid) {
+		List<PatternContainer> list = new ArrayList<>();
+		if (grid == null) return list;
+		try {
+			for (var machineClass : grid.getMachineClasses()) {
+				if (PatternContainer.class.isAssignableFrom(machineClass)) {
+					@SuppressWarnings("unchecked")
+					Class<? extends PatternContainer> containerClass = (Class<? extends PatternContainer>) machineClass;
+					for (var container : grid.getActiveMachines(containerClass)) {
+						if (container == null || !container.isVisibleInTerminal()) continue;
+						InternalInventory inv = container.getTerminalPatternInventory();
+						if (inv == null || inv.size() <= 0) continue;
+						list.add(container);
+					}
+				}
+			}
+		} catch (Throwable ignored) {
+		}
+		return list;
+	}
+}

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/BatchPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/BatchPatternUploadUtil.java
@@ -13,6 +13,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -73,22 +74,21 @@ public final class BatchPatternUploadUtil {
 			return existing;
 		}
 
-		try {
-			for (MatrixInventoryTarget target : ExtendedAEPatternUploadUtil.findAllMatrixPatternInventories(grid)) {
-				InternalInventory inv = target == null ? null : target.patternInventory();
-				collectFrom(inv, inv == null ? 0 : inv.size(), existing);
+		for (MatrixInventoryTarget target : ExtendedAEPatternUploadUtil.findAllMatrixPatternInventories(grid)) {
+			if (target == null) {
+				continue;
 			}
-		} catch (Throwable ignored) {
+			InternalInventory inv = target.patternInventory();
+			collectFrom(inv, inv == null ? 0 : inv.size(), existing);
 		}
 
 		if (providers != null) {
 			for (PatternContainer container : providers) {
-				if (container == null) continue;
-				try {
-					collectFrom(container.getTerminalPatternInventory(),
-							ExtendedAEPatternUploadUtil.getAccessiblePatternSlotCount(container), existing);
-				} catch (Throwable ignored) {
+				if (container == null) {
+					continue;
 				}
+				collectFrom(container.getTerminalPatternInventory(),
+						ExtendedAEPatternUploadUtil.getAccessiblePatternSlotCount(container), existing);
 			}
 		}
 		return existing;
@@ -126,41 +126,53 @@ public final class BatchPatternUploadUtil {
 	// --------------------------- 依映射挑供应器 ---------------------------
 
 	// 优先使用 JEC 的拼音匹配，否则回退到大小写不敏感子串匹配
-	private static Boolean JEC_AVAILABLE = null;
-	private static java.lang.reflect.Method JEC_CONTAINS = null;
+	private static boolean JEC_RESOLVED = false;
+	private static Method JEC_CONTAINS = null;
 
 	/**
 	 * 供应器名称与搜索词的匹配（客户端选择界面与服务端定向上传共用同一语义）。
 	 * 空搜索词视为全部匹配。
 	 */
 	public static boolean providerNameMatches(String name, String key) {
-		if (name == null) return false;
-		if (key == null || key.isEmpty()) return true;
-		try {
-			if (JEC_AVAILABLE == null) {
-				try {
-					Class<?> cls = Class.forName("me.towdium.jecharacters.utils.Match");
-					// 使用 contains(CharSequence, CharSequence)
-					JEC_CONTAINS = cls.getMethod("contains", CharSequence.class, CharSequence.class);
-					JEC_AVAILABLE = true;
-				} catch (Throwable t) {
-					JEC_AVAILABLE = false;
-				}
-			}
-			if (Boolean.TRUE.equals(JEC_AVAILABLE) && JEC_CONTAINS != null) {
-				Object r = JEC_CONTAINS.invoke(null, name, key);
-				if (r instanceof Boolean && (Boolean) r) return true;
-				// 再尝试大小写不敏感：双方转为小写重新匹配
-				String nL = name.toLowerCase();
-				String kL = key.toLowerCase();
-				Object r2 = JEC_CONTAINS.invoke(null, nL, kL);
-				if (r2 instanceof Boolean && (Boolean) r2) return true;
-			}
-		} catch (Throwable ignored) {
-			// 回退
+		if (name == null) {
+			return false;
+		}
+		if (key == null || key.isEmpty()) {
+			return true;
+		}
+		if (jecContains() != null && jecMatches(name, key)) {
+			return true;
 		}
 		// 默认大小写不敏感子串
 		return name.toLowerCase().contains(key.toLowerCase());
+	}
+
+	/** JEC 的 Match.contains；未装 JEC 时返回 null。反射解析只做一次，结果缓存。 */
+	private static Method jecContains() {
+		if (JEC_RESOLVED) {
+			return JEC_CONTAINS;
+		}
+		JEC_RESOLVED = true;
+		try {
+			JEC_CONTAINS = Class.forName("me.towdium.jecharacters.utils.Match")
+					.getMethod("contains", CharSequence.class, CharSequence.class);
+		} catch (ReflectiveOperationException notInstalled) {
+			JEC_CONTAINS = null;
+		}
+		return JEC_CONTAINS;
+	}
+
+	/** 原样匹配一次，再用双方小写各匹配一次（JEC 自身不保证大小写不敏感）。 */
+	private static boolean jecMatches(String name, String key) {
+		return jecContains(name, key) || jecContains(name.toLowerCase(), key.toLowerCase());
+	}
+
+	private static boolean jecContains(String name, String key) {
+		try {
+			return Boolean.TRUE.equals(JEC_CONTAINS.invoke(null, name, key));
+		} catch (ReflectiveOperationException failed) {
+			return false;
+		}
 	}
 
 	/**
@@ -213,21 +225,26 @@ public final class BatchPatternUploadUtil {
 	 */
 	public static List<PatternContainer> listAllProvidersFromGrid(IGrid grid) {
 		List<PatternContainer> list = new ArrayList<>();
-		if (grid == null) return list;
-		try {
-			for (var machineClass : grid.getMachineClasses()) {
-				if (PatternContainer.class.isAssignableFrom(machineClass)) {
-					@SuppressWarnings("unchecked")
-					Class<? extends PatternContainer> containerClass = (Class<? extends PatternContainer>) machineClass;
-					for (var container : grid.getActiveMachines(containerClass)) {
-						if (container == null || !container.isVisibleInTerminal()) continue;
-						InternalInventory inv = container.getTerminalPatternInventory();
-						if (inv == null || inv.size() <= 0) continue;
-						list.add(container);
-					}
-				}
+		if (grid == null) {
+			return list;
+		}
+
+		for (Class<?> machineClass : grid.getMachineClasses()) {
+			if (!PatternContainer.class.isAssignableFrom(machineClass)) {
+				continue;
 			}
-		} catch (Throwable ignored) {
+			@SuppressWarnings("unchecked")
+			Class<? extends PatternContainer> containerClass = (Class<? extends PatternContainer>) machineClass;
+			for (PatternContainer container : grid.getActiveMachines(containerClass)) {
+				if (container == null || !container.isVisibleInTerminal()) {
+					continue;
+				}
+				InternalInventory inv = container.getTerminalPatternInventory();
+				if (inv == null || inv.size() <= 0) {
+					continue;
+				}
+				list.add(container);
+			}
 		}
 		return list;
 	}

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
@@ -26,8 +26,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import it.unimi.dsi.fastutil.Hash;
-import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -62,9 +60,6 @@ public class ExtendedAEPatternUploadUtil {
     private static final String CONFIG_RELATIVE = "extendedae_plus/recipe_type_names.json";
     private static final Map<ResourceLocation, String> CUSTOM_NAMES = new ConcurrentHashMap<>();
     private static final Map<String, String> CUSTOM_ALIASES = new ConcurrentHashMap<>();
-    /** 每次重载映射表递增，供客户端缓存（如合成树映射标记）判断失效。 */
-    private static final java.util.concurrent.atomic.AtomicInteger MAPPING_VERSION =
-            new java.util.concurrent.atomic.AtomicInteger();
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     // 最近一次打开供应器选择界面时的预设搜索关键字。
     // 处理样板会写入映射后的配方类型关键字，合成样板固定使用 crafting（可通过映射改名）。
@@ -88,7 +83,7 @@ public class ExtendedAEPatternUploadUtil {
 
     private record HostLocator(long pos, String side, String dimension) {}
 
-    private record MatrixInventoryTarget(InternalInventory insertInventory,
+    record MatrixInventoryTarget(InternalInventory insertInventory,
                                          InternalInventory patternInventory,
                                          BlockPos pos,
                                          boolean plus) {}
@@ -150,125 +145,8 @@ public class ExtendedAEPatternUploadUtil {
             CUSTOM_NAMES.putAll(map);
             CUSTOM_ALIASES.clear();
             CUSTOM_ALIASES.putAll(alias);
-            MAPPING_VERSION.incrementAndGet();
         } catch (IOException ignored) {
         }
-    }
-
-    /** 映射表版本号：每次重载递增，客户端缓存据此失效。 */
-    public static int getMappingVersion() {
-        return MAPPING_VERSION.get();
-    }
-
-    /** 公开配方类型 ID 解析，供客户端判断映射状态。 */
-    public static ResourceLocation getRecipeTypeId(Recipe<?> recipe) {
-        return recipe == null ? null : resolveRecipeTypeId(recipe.getType());
-    }
-
-    /**
-     * 该配方类型是否存在用户自定义的供应器映射。
-     * 注意：{@link #resolveRecipeTypeSearchKey} 在无映射时会回退成 path，不能用它判断有无映射。
-     */
-    public static boolean hasCustomRecipeTypeMapping(ResourceLocation typeId) {
-        if (typeId == null) {
-            return false;
-        }
-        String custom = CUSTOM_NAMES.get(typeId);
-        if (custom != null && !custom.isBlank()) {
-            return true;
-        }
-        String alias = CUSTOM_ALIASES.get(typeId.getPath().toLowerCase(Locale.ROOT));
-        return alias != null && !alias.isBlank();
-    }
-
-    /** 有自定义映射时返回供应器搜索词，否则返回 null。 */
-    public static String mappedSearchKeyOrNull(Recipe<?> recipe) {
-        ResourceLocation typeId = getRecipeTypeId(recipe);
-        if (!hasCustomRecipeTypeMapping(typeId)) {
-            return null;
-        }
-        String key = resolveRecipeTypeSearchKey(typeId, null);
-        return key == null || key.isBlank() ? null : key;
-    }
-
-    // 优先使用 JEC 的拼音匹配，否则回退到大小写不敏感子串匹配
-    private static Boolean JEC_AVAILABLE = null;
-    private static java.lang.reflect.Method JEC_CONTAINS = null;
-
-    /**
-     * 供应器名称与搜索词的匹配（客户端选择界面与服务端定向上传共用同一语义）。
-     * 空搜索词视为全部匹配。
-     */
-    public static boolean providerNameMatches(String name, String key) {
-        if (name == null) return false;
-        if (key == null || key.isEmpty()) return true;
-        try {
-            if (JEC_AVAILABLE == null) {
-                try {
-                    Class<?> cls = Class.forName("me.towdium.jecharacters.utils.Match");
-                    // 使用 contains(CharSequence, CharSequence)
-                    JEC_CONTAINS = cls.getMethod("contains", CharSequence.class, CharSequence.class);
-                    JEC_AVAILABLE = true;
-                } catch (Throwable t) {
-                    JEC_AVAILABLE = false;
-                }
-            }
-            if (Boolean.TRUE.equals(JEC_AVAILABLE) && JEC_CONTAINS != null) {
-                Object r = JEC_CONTAINS.invoke(null, name, key);
-                if (r instanceof Boolean && (Boolean) r) return true;
-                // 再尝试大小写不敏感：双方转为小写重新匹配
-                String nL = name.toLowerCase();
-                String kL = key.toLowerCase();
-                Object r2 = JEC_CONTAINS.invoke(null, nL, kL);
-                if (r2 instanceof Boolean && (Boolean) r2) return true;
-            }
-        } catch (Throwable ignored) {
-            // 回退
-        }
-        // 默认大小写不敏感子串
-        return name.toLowerCase().contains(key.toLowerCase());
-    }
-
-    /**
-     * 依映射搜索词在给定供应器列表中寻找名称匹配者并插入样板。
-     * 空位多的优先，避免把整棵树的样板全挤到同一台机器上。
-     * 批量上传专用：不记录 last uploaded provider（一批 N 个样板的“最后一个”没有意义）。
-     */
-    public static boolean uploadPatternToMatchingProvider(ServerPlayer player,
-                                                         ItemStack pattern,
-                                                         List<PatternContainer> providers,
-                                                         String searchKey) {
-        if (player == null || pattern == null || pattern.isEmpty()
-                || searchKey == null || searchKey.isBlank()
-                || providers == null || providers.isEmpty()) {
-            return false;
-        }
-
-        List<PatternContainer> matched = new ArrayList<>();
-        for (PatternContainer container : providers) {
-            if (container == null) continue;
-            if (providerNameMatches(getProviderDisplayNameComponent(container).getString(), searchKey)) {
-                matched.add(container);
-            }
-        }
-        if (matched.isEmpty()) {
-            return false;
-        }
-        // getAvailableSlots 有重载，方法引用无法在 reversed() 处推断类型，显式声明比较器元素类型。
-        Comparator<PatternContainer> bySlotsDesc =
-                Comparator.comparingInt((PatternContainer c) -> getAvailableSlots(c)).reversed();
-        matched.sort(bySlotsDesc);
-
-        // 查重不在这里做：会把「已存在」和「插不进去」混成同一个 false，
-        // 导致调用方误判为失败而把样板塞进背包。查重由调用方在尝试上传前用
-        // collectExistingPatterns 一次性完成。
-        for (PatternContainer container : matched) {
-            ItemStack remain = insertIntoAccessiblePatternSlots(container, pattern.copy(), null);
-            if (remain.isEmpty()) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public static void setLastProcessingName(String name) {
@@ -948,7 +826,7 @@ public class ExtendedAEPatternUploadUtil {
      * 在给定 AE Grid 中收集所有已成型且在线的装配矩阵“图样模块”的用于外部插入的内部库存。
      * 优先使用 TileAssemblerMatrixPattern#getExposedInventory（仅允许插入，且已带AE过滤规则）。
      */
-    private static List<MatrixInventoryTarget> findAllMatrixPatternInventories(IGrid grid) {
+    static List<MatrixInventoryTarget> findAllMatrixPatternInventories(IGrid grid) {
         List<MatrixInventoryTarget> result = new ArrayList<>();
         if(grid== null) return result;
         try {
@@ -1063,146 +941,28 @@ public class ExtendedAEPatternUploadUtil {
         return java.util.Collections.emptyList();
     }
 
-    // --------------------------- 重复样板检测 ---------------------------
-
-    /**
-     * 忽略编码者信息后的样板副本，用于判定「是不是同一份样板」。
-     * {@code encodePlayer} 只记录是谁编的，不影响样板功能，必须排除在比较之外。
-     */
-    private static ItemStack normalizePatternForCompare(ItemStack pattern) {
-        ItemStack copy = pattern.copy();
-        CompoundTag tag = copy.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.of(new CompoundTag())).copyTag();
-        tag.remove("encodePlayer");
-        copy.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
-        return copy;
-    }
-
-    /** 两个样板是否是同一份（忽略编码者）。 */
-    public static boolean isSamePattern(ItemStack a, ItemStack b) {
-        if (a == null || b == null || a.isEmpty() || b.isEmpty()) {
-            return false;
-        }
-        return ItemStack.isSameItemSameComponents(normalizePatternForCompare(a), normalizePatternForCompare(b));
-    }
-
-    /**
-     * 建立「忽略编码者」的样板集合，与 {@link #isSamePattern} 同一套等价语义。
-     * 与本类其它地方一致地复用 {@code hashItemAndComponents} / {@code isSameItemSameComponents} 配对。
-     */
-    public static Set<ItemStack> newPatternSet() {
-        return new ObjectOpenCustomHashSet<>(new Hash.Strategy<>() {
-            @Override
-            public int hashCode(ItemStack stack) {
-                return stack == null ? 0 : ItemStack.hashItemAndComponents(stack);
-            }
-
-            @Override
-            public boolean equals(ItemStack a, ItemStack b) {
-                return a == b || (a != null && b != null && ItemStack.isSameItemSameComponents(a, b));
-            }
-        });
-    }
-
-    /**
-     * 收集网络中已存在的样板（装配矩阵 + 样板供应器），供批量编码一次性查重。
-     * <p>
-     * 批量编码若逐个样板扫全网，复杂度是 O(样板数 × 供应器数 × 槽位数)，
-     * 大网络上足以造成明显卡顿；因此扫一遍建成哈希集合，之后每次查重都是 O(1)。
-     * 新放进去的样板要由调用方 {@link #rememberPattern} 补进集合，集合不会自动跟随库存变化。
-     *
-     * @param providers 供应器快照；传 null 表示只看装配矩阵
-     */
-    public static Set<ItemStack> collectExistingPatterns(IGrid grid, List<PatternContainer> providers) {
-        Set<ItemStack> existing = newPatternSet();
-        if (grid == null) {
-            return existing;
-        }
-
-        try {
-            for (MatrixInventoryTarget target : findAllMatrixPatternInventories(grid)) {
-                InternalInventory inv = target == null ? null : target.patternInventory();
-                collectFrom(inv, inv == null ? 0 : inv.size(), existing);
-            }
-        } catch (Throwable ignored) {
-        }
-
-        if (providers != null) {
-            for (PatternContainer container : providers) {
-                if (container == null) continue;
-                try {
-                    InternalInventory inv = container.getTerminalPatternInventory();
-                    collectFrom(inv, getAccessiblePatternSlotCount(container, inv), existing);
-                } catch (Throwable ignored) {
-                }
-            }
-        }
-        return existing;
-    }
-
-    private static void collectFrom(InternalInventory inv, int slotLimit, Set<ItemStack> out) {
-        if (inv == null) {
-            return;
-        }
-        int limit = Math.max(0, Math.min(inv.size(), slotLimit));
-        for (int i = 0; i < limit; i++) {
-            ItemStack stack = inv.getStackInSlot(i);
-            if (stack != null && !stack.isEmpty() && PatternDetailsHelper.isEncodedPattern(stack)) {
-                out.add(normalizePatternForCompare(stack));
-            }
-        }
-    }
-
-    /** 集合里是否已有这份样板。 */
-    public static boolean containsPattern(Set<ItemStack> existing, ItemStack pattern) {
-        if (existing == null || existing.isEmpty() || pattern == null || pattern.isEmpty()) {
-            return false;
-        }
-        return existing.contains(normalizePatternForCompare(pattern));
-    }
-
-    /** 样板成功放入网络后登记进集合，让同一批里的后续项也能查到。 */
-    public static void rememberPattern(Set<ItemStack> existing, ItemStack pattern) {
-        if (existing == null || pattern == null || pattern.isEmpty()) {
-            return;
-        }
-        existing.add(normalizePatternForCompare(pattern));
-    }
-
-    /** 装配矩阵是否已存在同一样板（忽略编码者等自定义数据）。批量编码用来跳过重复项，不白扣空白样板。 */
-    public static boolean matrixHasPattern(IGrid grid, ItemStack pattern) {
-        return matrixContainsPattern(grid, pattern);
-    }
-
-    /** 该供应器里是否已存在同一样板。 */
-    public static boolean providerHasPattern(PatternContainer container, ItemStack pattern) {
-        if (container == null || pattern == null || pattern.isEmpty()) {
-            return false;
-        }
-        try {
-            InternalInventory inv = container.getTerminalPatternInventory();
-            if (inv == null) {
-                return false;
-            }
-            int limit = Math.max(0, Math.min(inv.size(), getAccessiblePatternSlotCount(container, inv)));
-            for (int i = 0; i < limit; i++) {
-                if (isSamePattern(inv.getStackInSlot(i), pattern)) {
-                    return true;
-                }
-            }
-        } catch (Throwable ignored) {
-        }
-        return false;
-    }
-
     private static boolean matrixContainsPattern(IGrid grid, ItemStack pattern) {
         if (grid == null || pattern == null || pattern.isEmpty()) return false;
+        CustomData defaultData = CustomData.of(new CompoundTag());
+        ItemStack patternCopy = pattern.copy();
+        CompoundTag newTag= patternCopy.getOrDefault(DataComponents.CUSTOM_DATA,defaultData).copyTag();
+        newTag.remove("encodePlayer");
+        patternCopy.set(DataComponents.CUSTOM_DATA, CustomData.of(newTag));
         try {
             // 先检查提供外部插入视图的内部库存
-            for (MatrixInventoryTarget target : findAllMatrixPatternInventories(grid)) {
+            List<MatrixInventoryTarget> inventories = findAllMatrixPatternInventories(grid);
+            for (MatrixInventoryTarget target : inventories) {
                 InternalInventory inv = target == null ? null : target.patternInventory();
                 if (inv == null) continue;
                 for (int i = 0; i < inv.size(); i++) {
-                    if (isSamePattern(inv.getStackInSlot(i), pattern)) {
+                    ItemStack s = inv.getStackInSlot(i);
+
+                    ItemStack sCopy=s.copy();
+                    CompoundTag sNewTag=sCopy.getOrDefault(DataComponents.CUSTOM_DATA,defaultData).copyTag();
+                    sNewTag.remove("encodePlayer");
+                    sCopy.set(DataComponents.CUSTOM_DATA, CustomData.of(sNewTag));
+
+                    if (!sCopy.isEmpty() && ItemStack.isSameItemSameComponents(sCopy, patternCopy)) {
                         return true;
                     }
                 }
@@ -1911,31 +1671,6 @@ public class ExtendedAEPatternUploadUtil {
                                 break;
                             }
                         }
-                    }
-                }
-            }
-        } catch (Throwable ignored) {
-        }
-        return list;
-    }
-
-    /**
-     * 列出网络中所有终端可见的样板供应器（不筛空位）。
-     * 供“为配方类型挑选机器建立映射”使用：映射只关心名字，机器当下满不满无关。
-     */
-    public static List<PatternContainer> listAllProvidersFromGrid(IGrid grid) {
-        List<PatternContainer> list = new ArrayList<>();
-        if (grid == null) return list;
-        try {
-            for (var machineClass : grid.getMachineClasses()) {
-                if (PatternContainer.class.isAssignableFrom(machineClass)) {
-                    @SuppressWarnings("unchecked")
-                    Class<? extends PatternContainer> containerClass = (Class<? extends PatternContainer>) machineClass;
-                    for (var container : grid.getActiveMachines(containerClass)) {
-                        if (container == null || !container.isVisibleInTerminal()) continue;
-                        InternalInventory inv = container.getTerminalPatternInventory();
-                        if (inv == null || inv.size() <= 0) continue;
-                        list.add(container);
                     }
                 }
             }

--- a/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
+++ b/src/main/java/com/extendedae_plus/util/uploadPattern/ExtendedAEPatternUploadUtil.java
@@ -26,6 +26,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -60,6 +62,9 @@ public class ExtendedAEPatternUploadUtil {
     private static final String CONFIG_RELATIVE = "extendedae_plus/recipe_type_names.json";
     private static final Map<ResourceLocation, String> CUSTOM_NAMES = new ConcurrentHashMap<>();
     private static final Map<String, String> CUSTOM_ALIASES = new ConcurrentHashMap<>();
+    /** 每次重载映射表递增，供客户端缓存（如合成树映射标记）判断失效。 */
+    private static final java.util.concurrent.atomic.AtomicInteger MAPPING_VERSION =
+            new java.util.concurrent.atomic.AtomicInteger();
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     // 最近一次打开供应器选择界面时的预设搜索关键字。
     // 处理样板会写入映射后的配方类型关键字，合成样板固定使用 crafting（可通过映射改名）。
@@ -145,8 +150,125 @@ public class ExtendedAEPatternUploadUtil {
             CUSTOM_NAMES.putAll(map);
             CUSTOM_ALIASES.clear();
             CUSTOM_ALIASES.putAll(alias);
+            MAPPING_VERSION.incrementAndGet();
         } catch (IOException ignored) {
         }
+    }
+
+    /** 映射表版本号：每次重载递增，客户端缓存据此失效。 */
+    public static int getMappingVersion() {
+        return MAPPING_VERSION.get();
+    }
+
+    /** 公开配方类型 ID 解析，供客户端判断映射状态。 */
+    public static ResourceLocation getRecipeTypeId(Recipe<?> recipe) {
+        return recipe == null ? null : resolveRecipeTypeId(recipe.getType());
+    }
+
+    /**
+     * 该配方类型是否存在用户自定义的供应器映射。
+     * 注意：{@link #resolveRecipeTypeSearchKey} 在无映射时会回退成 path，不能用它判断有无映射。
+     */
+    public static boolean hasCustomRecipeTypeMapping(ResourceLocation typeId) {
+        if (typeId == null) {
+            return false;
+        }
+        String custom = CUSTOM_NAMES.get(typeId);
+        if (custom != null && !custom.isBlank()) {
+            return true;
+        }
+        String alias = CUSTOM_ALIASES.get(typeId.getPath().toLowerCase(Locale.ROOT));
+        return alias != null && !alias.isBlank();
+    }
+
+    /** 有自定义映射时返回供应器搜索词，否则返回 null。 */
+    public static String mappedSearchKeyOrNull(Recipe<?> recipe) {
+        ResourceLocation typeId = getRecipeTypeId(recipe);
+        if (!hasCustomRecipeTypeMapping(typeId)) {
+            return null;
+        }
+        String key = resolveRecipeTypeSearchKey(typeId, null);
+        return key == null || key.isBlank() ? null : key;
+    }
+
+    // 优先使用 JEC 的拼音匹配，否则回退到大小写不敏感子串匹配
+    private static Boolean JEC_AVAILABLE = null;
+    private static java.lang.reflect.Method JEC_CONTAINS = null;
+
+    /**
+     * 供应器名称与搜索词的匹配（客户端选择界面与服务端定向上传共用同一语义）。
+     * 空搜索词视为全部匹配。
+     */
+    public static boolean providerNameMatches(String name, String key) {
+        if (name == null) return false;
+        if (key == null || key.isEmpty()) return true;
+        try {
+            if (JEC_AVAILABLE == null) {
+                try {
+                    Class<?> cls = Class.forName("me.towdium.jecharacters.utils.Match");
+                    // 使用 contains(CharSequence, CharSequence)
+                    JEC_CONTAINS = cls.getMethod("contains", CharSequence.class, CharSequence.class);
+                    JEC_AVAILABLE = true;
+                } catch (Throwable t) {
+                    JEC_AVAILABLE = false;
+                }
+            }
+            if (Boolean.TRUE.equals(JEC_AVAILABLE) && JEC_CONTAINS != null) {
+                Object r = JEC_CONTAINS.invoke(null, name, key);
+                if (r instanceof Boolean && (Boolean) r) return true;
+                // 再尝试大小写不敏感：双方转为小写重新匹配
+                String nL = name.toLowerCase();
+                String kL = key.toLowerCase();
+                Object r2 = JEC_CONTAINS.invoke(null, nL, kL);
+                if (r2 instanceof Boolean && (Boolean) r2) return true;
+            }
+        } catch (Throwable ignored) {
+            // 回退
+        }
+        // 默认大小写不敏感子串
+        return name.toLowerCase().contains(key.toLowerCase());
+    }
+
+    /**
+     * 依映射搜索词在给定供应器列表中寻找名称匹配者并插入样板。
+     * 空位多的优先，避免把整棵树的样板全挤到同一台机器上。
+     * 批量上传专用：不记录 last uploaded provider（一批 N 个样板的“最后一个”没有意义）。
+     */
+    public static boolean uploadPatternToMatchingProvider(ServerPlayer player,
+                                                         ItemStack pattern,
+                                                         List<PatternContainer> providers,
+                                                         String searchKey) {
+        if (player == null || pattern == null || pattern.isEmpty()
+                || searchKey == null || searchKey.isBlank()
+                || providers == null || providers.isEmpty()) {
+            return false;
+        }
+
+        List<PatternContainer> matched = new ArrayList<>();
+        for (PatternContainer container : providers) {
+            if (container == null) continue;
+            if (providerNameMatches(getProviderDisplayNameComponent(container).getString(), searchKey)) {
+                matched.add(container);
+            }
+        }
+        if (matched.isEmpty()) {
+            return false;
+        }
+        // getAvailableSlots 有重载，方法引用无法在 reversed() 处推断类型，显式声明比较器元素类型。
+        Comparator<PatternContainer> bySlotsDesc =
+                Comparator.comparingInt((PatternContainer c) -> getAvailableSlots(c)).reversed();
+        matched.sort(bySlotsDesc);
+
+        // 查重不在这里做：会把「已存在」和「插不进去」混成同一个 false，
+        // 导致调用方误判为失败而把样板塞进背包。查重由调用方在尝试上传前用
+        // collectExistingPatterns 一次性完成。
+        for (PatternContainer container : matched) {
+            ItemStack remain = insertIntoAccessiblePatternSlots(container, pattern.copy(), null);
+            if (remain.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static void setLastProcessingName(String name) {
@@ -747,6 +869,13 @@ public class ExtendedAEPatternUploadUtil {
      * @return 是否成功插入矩阵
      */
     public static boolean uploadPatternToMatrix(ServerPlayer player, ItemStack pattern, IGrid grid) {
+        return uploadPatternToMatrix(player, pattern, grid, false);
+    }
+
+    /**
+     * @param quiet 批量上传时抑制逐个样板的聊天提示，由调用方汇总后统一告知玩家。
+     */
+    public static boolean uploadPatternToMatrix(ServerPlayer player, ItemStack pattern, IGrid grid, boolean quiet) {
         if (player == null || grid == null || pattern == null || pattern.isEmpty() || !PatternDetailsHelper.isEncodedPattern(pattern)) {
             return false;
         }
@@ -755,12 +884,14 @@ public class ExtendedAEPatternUploadUtil {
         if (!(details instanceof AECraftingPattern
                 || details instanceof AESmithingTablePattern
                 || details instanceof AEStonecuttingPattern)) {
-            sendMessage(player, "extendedae_plus.upload_to_matrix.fail");
+            if (!quiet) {
+                sendMessage(player, "extendedae_plus.upload_to_matrix.fail");
+            }
             return false;
         }
 
         if (matrixContainsPattern(grid, pattern)) {
-            if (player != null) {
+            if (!quiet) {
                 player.sendSystemMessage(Component.translatable("extendedae_plus.message.matrix.duplicate"));
             }
             return false;
@@ -781,7 +912,9 @@ public class ExtendedAEPatternUploadUtil {
                             target.plus(),
                             findLastChangedSlot(target.patternInventory(), before, target.patternInventory().size())
                     );
-                    sendMessage(player, "extendedae_plus.upload_to_matrix.success");
+                    if (!quiet) {
+                        sendMessage(player, "extendedae_plus.upload_to_matrix.success");
+                    }
                     return true;
                 }
             }
@@ -793,16 +926,20 @@ public class ExtendedAEPatternUploadUtil {
                 ItemStack toInsert = pattern.copy();
                 ItemStack remain = insertIntoAnySlot(cap, toInsert);
                 if (remain.getCount() < toInsert.getCount()) {
-                    sendMessage(player, "extendedae_plus.upload_to_matrix.success");
+                    if (!quiet) {
+                        sendMessage(player, "extendedae_plus.upload_to_matrix.success");
+                    }
                     return true;
                 }
             }
         }
 
-        if (inventories.isEmpty() && handlers.isEmpty()) {
-            sendMessage(player, "extendedae_plus.upload_to_matrix.fail_no_matrix");
-        } else {
-            sendMessage(player, "extendedae_plus.upload_to_matrix.fail_full");
+        if (!quiet) {
+            if (inventories.isEmpty() && handlers.isEmpty()) {
+                sendMessage(player, "extendedae_plus.upload_to_matrix.fail_no_matrix");
+            } else {
+                sendMessage(player, "extendedae_plus.upload_to_matrix.fail_full");
+            }
         }
         return false;
     }
@@ -926,28 +1063,146 @@ public class ExtendedAEPatternUploadUtil {
         return java.util.Collections.emptyList();
     }
 
+    // --------------------------- 重复样板检测 ---------------------------
+
+    /**
+     * 忽略编码者信息后的样板副本，用于判定「是不是同一份样板」。
+     * {@code encodePlayer} 只记录是谁编的，不影响样板功能，必须排除在比较之外。
+     */
+    private static ItemStack normalizePatternForCompare(ItemStack pattern) {
+        ItemStack copy = pattern.copy();
+        CompoundTag tag = copy.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.of(new CompoundTag())).copyTag();
+        tag.remove("encodePlayer");
+        copy.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        return copy;
+    }
+
+    /** 两个样板是否是同一份（忽略编码者）。 */
+    public static boolean isSamePattern(ItemStack a, ItemStack b) {
+        if (a == null || b == null || a.isEmpty() || b.isEmpty()) {
+            return false;
+        }
+        return ItemStack.isSameItemSameComponents(normalizePatternForCompare(a), normalizePatternForCompare(b));
+    }
+
+    /**
+     * 建立「忽略编码者」的样板集合，与 {@link #isSamePattern} 同一套等价语义。
+     * 与本类其它地方一致地复用 {@code hashItemAndComponents} / {@code isSameItemSameComponents} 配对。
+     */
+    public static Set<ItemStack> newPatternSet() {
+        return new ObjectOpenCustomHashSet<>(new Hash.Strategy<>() {
+            @Override
+            public int hashCode(ItemStack stack) {
+                return stack == null ? 0 : ItemStack.hashItemAndComponents(stack);
+            }
+
+            @Override
+            public boolean equals(ItemStack a, ItemStack b) {
+                return a == b || (a != null && b != null && ItemStack.isSameItemSameComponents(a, b));
+            }
+        });
+    }
+
+    /**
+     * 收集网络中已存在的样板（装配矩阵 + 样板供应器），供批量编码一次性查重。
+     * <p>
+     * 批量编码若逐个样板扫全网，复杂度是 O(样板数 × 供应器数 × 槽位数)，
+     * 大网络上足以造成明显卡顿；因此扫一遍建成哈希集合，之后每次查重都是 O(1)。
+     * 新放进去的样板要由调用方 {@link #rememberPattern} 补进集合，集合不会自动跟随库存变化。
+     *
+     * @param providers 供应器快照；传 null 表示只看装配矩阵
+     */
+    public static Set<ItemStack> collectExistingPatterns(IGrid grid, List<PatternContainer> providers) {
+        Set<ItemStack> existing = newPatternSet();
+        if (grid == null) {
+            return existing;
+        }
+
+        try {
+            for (MatrixInventoryTarget target : findAllMatrixPatternInventories(grid)) {
+                InternalInventory inv = target == null ? null : target.patternInventory();
+                collectFrom(inv, inv == null ? 0 : inv.size(), existing);
+            }
+        } catch (Throwable ignored) {
+        }
+
+        if (providers != null) {
+            for (PatternContainer container : providers) {
+                if (container == null) continue;
+                try {
+                    InternalInventory inv = container.getTerminalPatternInventory();
+                    collectFrom(inv, getAccessiblePatternSlotCount(container, inv), existing);
+                } catch (Throwable ignored) {
+                }
+            }
+        }
+        return existing;
+    }
+
+    private static void collectFrom(InternalInventory inv, int slotLimit, Set<ItemStack> out) {
+        if (inv == null) {
+            return;
+        }
+        int limit = Math.max(0, Math.min(inv.size(), slotLimit));
+        for (int i = 0; i < limit; i++) {
+            ItemStack stack = inv.getStackInSlot(i);
+            if (stack != null && !stack.isEmpty() && PatternDetailsHelper.isEncodedPattern(stack)) {
+                out.add(normalizePatternForCompare(stack));
+            }
+        }
+    }
+
+    /** 集合里是否已有这份样板。 */
+    public static boolean containsPattern(Set<ItemStack> existing, ItemStack pattern) {
+        if (existing == null || existing.isEmpty() || pattern == null || pattern.isEmpty()) {
+            return false;
+        }
+        return existing.contains(normalizePatternForCompare(pattern));
+    }
+
+    /** 样板成功放入网络后登记进集合，让同一批里的后续项也能查到。 */
+    public static void rememberPattern(Set<ItemStack> existing, ItemStack pattern) {
+        if (existing == null || pattern == null || pattern.isEmpty()) {
+            return;
+        }
+        existing.add(normalizePatternForCompare(pattern));
+    }
+
+    /** 装配矩阵是否已存在同一样板（忽略编码者等自定义数据）。批量编码用来跳过重复项，不白扣空白样板。 */
+    public static boolean matrixHasPattern(IGrid grid, ItemStack pattern) {
+        return matrixContainsPattern(grid, pattern);
+    }
+
+    /** 该供应器里是否已存在同一样板。 */
+    public static boolean providerHasPattern(PatternContainer container, ItemStack pattern) {
+        if (container == null || pattern == null || pattern.isEmpty()) {
+            return false;
+        }
+        try {
+            InternalInventory inv = container.getTerminalPatternInventory();
+            if (inv == null) {
+                return false;
+            }
+            int limit = Math.max(0, Math.min(inv.size(), getAccessiblePatternSlotCount(container, inv)));
+            for (int i = 0; i < limit; i++) {
+                if (isSamePattern(inv.getStackInSlot(i), pattern)) {
+                    return true;
+                }
+            }
+        } catch (Throwable ignored) {
+        }
+        return false;
+    }
+
     private static boolean matrixContainsPattern(IGrid grid, ItemStack pattern) {
         if (grid == null || pattern == null || pattern.isEmpty()) return false;
-        CustomData defaultData = CustomData.of(new CompoundTag());
-        ItemStack patternCopy = pattern.copy();
-        CompoundTag newTag= patternCopy.getOrDefault(DataComponents.CUSTOM_DATA,defaultData).copyTag();
-        newTag.remove("encodePlayer");
-        patternCopy.set(DataComponents.CUSTOM_DATA, CustomData.of(newTag));
         try {
             // 先检查提供外部插入视图的内部库存
-            List<MatrixInventoryTarget> inventories = findAllMatrixPatternInventories(grid);
-            for (MatrixInventoryTarget target : inventories) {
+            for (MatrixInventoryTarget target : findAllMatrixPatternInventories(grid)) {
                 InternalInventory inv = target == null ? null : target.patternInventory();
                 if (inv == null) continue;
                 for (int i = 0; i < inv.size(); i++) {
-                    ItemStack s = inv.getStackInSlot(i);
-
-                    ItemStack sCopy=s.copy();
-                    CompoundTag sNewTag=sCopy.getOrDefault(DataComponents.CUSTOM_DATA,defaultData).copyTag();
-                    sNewTag.remove("encodePlayer");
-                    sCopy.set(DataComponents.CUSTOM_DATA, CustomData.of(sNewTag));
-
-                    if (!sCopy.isEmpty() && ItemStack.isSameItemSameComponents(sCopy, patternCopy)) {
+                    if (isSamePattern(inv.getStackInSlot(i), pattern)) {
                         return true;
                     }
                 }
@@ -1656,6 +1911,31 @@ public class ExtendedAEPatternUploadUtil {
                                 break;
                             }
                         }
+                    }
+                }
+            }
+        } catch (Throwable ignored) {
+        }
+        return list;
+    }
+
+    /**
+     * 列出网络中所有终端可见的样板供应器（不筛空位）。
+     * 供“为配方类型挑选机器建立映射”使用：映射只关心名字，机器当下满不满无关。
+     */
+    public static List<PatternContainer> listAllProvidersFromGrid(IGrid grid) {
+        List<PatternContainer> list = new ArrayList<>();
+        if (grid == null) return list;
+        try {
+            for (var machineClass : grid.getMachineClasses()) {
+                if (PatternContainer.class.isAssignableFrom(machineClass)) {
+                    @SuppressWarnings("unchecked")
+                    Class<? extends PatternContainer> containerClass = (Class<? extends PatternContainer>) machineClass;
+                    for (var container : grid.getActiveMachines(containerClass)) {
+                        if (container == null || !container.isVisibleInTerminal()) continue;
+                        InternalInventory inv = container.getTerminalPatternInventory();
+                        if (inv == null || inv.size() <= 0) continue;
+                        list.add(container);
                     }
                 }
             }

--- a/src/main/resources/assets/extendedae_plus/lang/en_us.json
+++ b/src/main/resources/assets/extendedae_plus/lang/en_us.json
@@ -185,6 +185,10 @@
   "message.extendedae_plus.no_blank_pattern": "No blank pattern available.",
   "message.extendedae_plus.pattern_creation_failed": "Failed to create encoded pattern.",
   "message.extendedae_plus.no_network": "Unable to access AE network.",
+  "message.extendedae_plus.bom_encode.summary": "Batch encoding done: %s to assembler matrix, %s to providers, %s to inventory.",
+  "message.extendedae_plus.bom_encode.skipped_no_recipe": "Skipped %s node(s) whose recipe ID could not be resolved.",
+  "message.extendedae_plus.bom_encode.skipped_duplicate": "Skipped %s pattern(s) already present in the network.",
+  "message.extendedae_plus.bom_encode.failed": "%s pattern(s) failed to encode; blank patterns were refunded.",
   "extendedae_plus.pattern.hovertext.player": "Encoded by %s",
 
   "item.extendedae_plus.entity_speed_ticker": "Entity Accelerator",

--- a/src/main/resources/assets/extendedae_plus/lang/zh_cn.json
+++ b/src/main/resources/assets/extendedae_plus/lang/zh_cn.json
@@ -186,6 +186,10 @@
   "message.extendedae_plus.no_blank_pattern": "没有可用空白样板。",
   "message.extendedae_plus.pattern_creation_failed": "创建编码样板失败。",
   "message.extendedae_plus.no_network": "无法访问 AE 网络。",
+  "message.extendedae_plus.bom_encode.summary": "批量编码完成：装配矩阵 %s 个，供应器 %s 个，背包 %s 个。",
+  "message.extendedae_plus.bom_encode.skipped_no_recipe": "已跳过 %s 个无法解析配方 ID 的节点。",
+  "message.extendedae_plus.bom_encode.skipped_duplicate": "已跳过 %s 个网络中已存在的样板。",
+  "message.extendedae_plus.bom_encode.failed": "%s 个样板编码失败，空白样板已退回。",
   "extendedae_plus.pattern.hovertext.player": "由 %s 编码",
 
   "item.extendedae_plus.entity_speed_ticker": "实体加速器",


### PR DESCRIPTION
基于 `1.21.1`（892bfdf8）的 1 个提交。原 #127 拆分出的第 4 部分，与 #132、#133 互不依赖，可独立合并。

### 批量编码上传的服务端路径

一次性编码整棵合成链需要的服务端能力，与查看器（EMI / JEI）无关，不引用任何客户端界面类。本 PR 只提供封包与工具，**发送方（合成树上的上传按钮）在 #134 里接上**——单独合并本 PR 不会改变现有游戏行为，只是把这段逻辑先摘出来单独评审。

批量走单封包 `BatchCreateAndUploadPatternC2SPacket`，逐条按「装配矩阵 → 依映射匹配的供应器 → 背包」三段回退，最后只回一条汇总消息，而不是每个样板刷一行。条目数设上限，客户端超出时分批发，避免一棵大树塞爆一个数据包。

### 重复样板检测覆盖整个网络

原先只查装配矩阵，重复按会往供应器里反复塞同一份样板。改为编码后、扣空白样板前用「装配矩阵 + 样板供应器」的哈希集合查重：

- `collectExistingPatterns` 整批只扫一遍建集合，之后每次查重 O(1)；逐个样板扫全网是 O(样板数 × 供应器数 × 槽位数)，大网络上会卡
- 比较统一走 `isSamePattern`（忽略 `encodePlayer`），集合复用 `hashItemAndComponents` / `isSameItemSameComponents` 配对
- 成功放入或落背包的样板都登记回集合，服务端不依赖客户端已去重，避免被塞满同一条目的封包白扣整叠空白样板

### 与单个上传路径共用逻辑

`CreateAndUploadPatternC2SPacket` 的 `consumeBlankPattern` / `refundBlankPattern` / `encodePattern`（原 `createPattern`）放宽到包内可见，批量分支复用同一套逻辑，两条路径的空白样板扣减与退回行为保持一致。除了改名与可见性，单个上传路径的行为没有变化。

---

测试：`./gradlew build`（JDK 21）通过。仓库无测试源码；封包的实际收发要等 #134 接上发送方才能在游戏内验证。
