### PR TITLE
feat: 优化 JEI 网络存量标识并加入终端设置开关

### DIFF
--- a/src/main/java/com/extendedae_plus/client/jei/JeiNetworkOverlayButton.java
+++ b/src/main/java/com/extendedae_plus/client/jei/JeiNetworkOverlayButton.java
@@ -82,7 +82,7 @@ public final class JeiNetworkOverlayButton implements IUserInputHandler {
         }
         if (!input.isSimulate()) {
             // JEI 会先模拟输入，只有实际点击阶段才切换并播放声音。
-            ModConfig.INSTANCE.jeiNetworkOverlayEnabled = !ModConfig.INSTANCE.jeiNetworkOverlayEnabled;
+            ModConfig.setJeiNetworkOverlayEnabled(!ModConfig.INSTANCE.jeiNetworkOverlayEnabled);
             Minecraft minecraft = Minecraft.getInstance();
             minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
         }

--- a/src/main/java/com/extendedae_plus/config/ModConfig.java
+++ b/src/main/java/com/extendedae_plus/config/ModConfig.java
@@ -47,6 +47,20 @@ public final class ModConfig {
         }
     }
 
+    /** Updates and immediately saves the JEI network inventory overlay preference. */
+    @SuppressWarnings("unchecked")
+    public static void setJeiNetworkOverlayEnabled(boolean enabled) {
+        synchronized (lock) {
+            if (INSTANCE == null || configHolder == null) {
+                return;
+            }
+            ConfigValue<Boolean> value = (ConfigValue<Boolean>) configHolder.getValueMap()
+                    .get("jeiNetworkOverlayEnabled");
+            value.set(enabled);
+            ConfigIO.saveClientValues(configHolder);
+        }
+    }
+
     @Configurable
     @Configurable.Comment(value = {
             "设置AE构建合成计划过程中的 wait/notify 次数，提升吞吐但会降低调度响应性"
@@ -124,7 +138,7 @@ public final class ModConfig {
     @Configurable
     @Configurable.Comment(value = {
             "JEI 中是否显示 AE2 网络库存与可合成状态",
-            "可通过 JEI 左下角按钮即时切换"
+            "可通过 JEI 左下角按钮或 AE2 终端设置即时切换"
     })
     public boolean jeiNetworkOverlayEnabled = true;
 

--- a/src/main/java/com/extendedae_plus/mixin/ae2/client/gui/TerminalSettingsScreenMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/ae2/client/gui/TerminalSettingsScreenMixin.java
@@ -1,0 +1,38 @@
+package com.extendedae_plus.mixin.ae2.client.gui;
+
+import appeng.client.gui.me.common.TerminalSettingsScreen;
+import appeng.client.gui.widgets.AECheckbox;
+import com.extendedae_plus.config.ModConfig;
+import com.extendedae_plus.mixin.ae2.accessor.AEBaseScreenAccessor;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.fml.ModList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/** Adds the JEI network inventory overlay preference to AE2's terminal settings screen. */
+@Mixin(value = TerminalSettingsScreen.class, remap = false)
+public abstract class TerminalSettingsScreenMixin {
+
+    @Unique
+    private AECheckbox eap$jeiNetworkOverlayCheckbox;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void eap$addJeiNetworkOverlaySetting(CallbackInfo ci) {
+        var widgets = ((AEBaseScreenAccessor<?>) this).eap$getWidgets();
+        this.eap$jeiNetworkOverlayCheckbox = widgets.addCheckbox(
+                "searchTooltipsCheckbox",
+                Component.translatable("gui.extendedae_plus.terminal_settings.jei_network_overlay"),
+                this::eap$saveJeiNetworkOverlaySetting
+        );
+        this.eap$jeiNetworkOverlayCheckbox.setSelected(ModConfig.INSTANCE.jeiNetworkOverlayEnabled);
+        this.eap$jeiNetworkOverlayCheckbox.active = ModList.get().isLoaded("jei");
+    }
+
+    @Unique
+    private void eap$saveJeiNetworkOverlaySetting() {
+        ModConfig.setJeiNetworkOverlayEnabled(this.eap$jeiNetworkOverlayCheckbox.isSelected());
+    }
+}

--- a/src/main/java/com/extendedae_plus/mixin/jei/IngredientListRendererMixin.java
+++ b/src/main/java/com/extendedae_plus/mixin/jei/IngredientListRendererMixin.java
@@ -69,7 +69,7 @@ public class IngredientListRendererMixin {
                     eap$renderCraftableMarker(guiGraphics, x, y);
                 }
             } else {
-                GuiUtil.drawAmountText(guiGraphics, font, "Craft", x, y);
+                GuiUtil.drawAmountText(guiGraphics, font, "+", x, y);
             }
         }
     }

--- a/src/main/resources/assets/extendedae_plus/lang/en_us.json
+++ b/src/main/resources/assets/extendedae_plus/lang/en_us.json
@@ -357,5 +357,6 @@
   "item.extendedae_plus.ultimate_super_assembler_matrix_builder.placed": "Ultimate Super Assembler Matrix built",
   "tooltip.extendedae_plus.jei_network_overlay.enabled": "AE2 network inventory display: Enabled",
   "tooltip.extendedae_plus.jei_network_overlay.disabled": "AE2 network inventory display: Disabled",
-  "tooltip.extendedae_plus.jei_network_overlay.description": "When carrying a usable AE2 wireless terminal, the current AE2 stock of each item is shown in bookmarks"
+  "tooltip.extendedae_plus.jei_network_overlay.description": "When carrying a usable AE2 wireless terminal, AE2 stock is shown in JEI's ingredient list and bookmarks",
+  "gui.extendedae_plus.terminal_settings.jei_network_overlay": "Show AE2 stock in JEI"
 }

--- a/src/main/resources/assets/extendedae_plus/lang/zh_cn.json
+++ b/src/main/resources/assets/extendedae_plus/lang/zh_cn.json
@@ -356,5 +356,6 @@
   "item.extendedae_plus.ultimate_super_assembler_matrix_builder.placed": "终极超级装配矩阵已搭建",
   "tooltip.extendedae_plus.jei_network_overlay.enabled": "AE2 网络库存显示：开启",
   "tooltip.extendedae_plus.jei_network_overlay.disabled": "AE2 网络库存显示：关闭",
-  "tooltip.extendedae_plus.jei_network_overlay.description": "当身上有可用的 AE2 无线终端时，会在书签中显示当前 AE2 中该物品库存"
+  "tooltip.extendedae_plus.jei_network_overlay.description": "当身上有可用的 AE2 无线终端时，会在 JEI 物品列表和书签中显示当前 AE2 库存",
+  "gui.extendedae_plus.terminal_settings.jei_network_overlay": "JEI 显示 AE2 网络库存"
 }

--- a/src/main/resources/assets/extendedae_plus/lang/zh_tw.json
+++ b/src/main/resources/assets/extendedae_plus/lang/zh_tw.json
@@ -270,5 +270,6 @@
   "key.categories.extendedae_plus": "ExtendedAE Plus",
   "tooltip.extendedae_plus.jei_network_overlay.enabled": "AE2 網路庫存顯示：開啟",
   "tooltip.extendedae_plus.jei_network_overlay.disabled": "AE2 網路庫存顯示：關閉",
-  "tooltip.extendedae_plus.jei_network_overlay.description": "當身上有可用的 AE2 無線終端時，會在書籤中顯示目前 AE2 中該物品庫存"
+  "tooltip.extendedae_plus.jei_network_overlay.description": "當身上有可用的 AE2 無線終端時，會在 JEI 物品列表和書籤中顯示目前 AE2 庫存",
+  "gui.extendedae_plus.terminal_settings.jei_network_overlay": "JEI 顯示 AE2 網路庫存"
 }

--- a/src/main/resources/extendedae_plus.mixins.json
+++ b/src/main/resources/extendedae_plus.mixins.json
@@ -21,6 +21,7 @@
     "ae2.client.gui.InterfaceScreenMixin",
     "ae2.client.gui.ProcessingEncodingPanelMixin",
     "ae2.client.gui.PatternEncodingTermScreenMixin",
+    "ae2.client.gui.TerminalSettingsScreenMixin",
     "ae2.client.gui.SlotGridLayoutMixin",
     "ae2.client.gui.patternProvider.PatternProviderHighlightCleanupMixin",
     "ae2.client.gui.patternProvider.PatternProviderScreenMixin",


### PR DESCRIPTION
## 简介

继续完善 #102 引入的 JEI 网络存量显示功能，让界面更简洁，并允许玩家从 AE2 的 Terminal Settings 中统一控制该功能。

## 改动

- 将可合成标识由 Craft 改为更紧凑的 +
- 在 Terminal Settings → Search Settings 中加入 Show AE2 stock in JEI 开关
- 开关状态持久保存，重启客户端后仍然生效
- JEI 左下角按钮与终端设置共用同一状态，任一入口切换都会同步
- 补充简体中文、繁体中文和英文文本

## 效果截图

截图将在 PR 创建后作为附件补充。

## 验证

- ./gradlew build --no-daemon --console=plain
- 使用代码生成的 AE2 自动合成测试世界验证：网络库存数量、仅可合成物品的 + 标记、设置开关与无线终端同步均可正常工作
